### PR TITLE
APPS-1235 - Not Crashing on Messages With a Single Message Part Image.

### DIFF
--- a/Atlas.xcodeproj/project.pbxproj
+++ b/Atlas.xcodeproj/project.pbxproj
@@ -12,6 +12,9 @@
 		CE7BDC080170509511B89900 /* libPods-UnitTests.a in Frameworks */ = {isa = PBXBuildFile; fileRef = F7012754989ED85BE6A8D69E /* libPods-UnitTests.a */; };
 		D0294DE71A93F37A00702856 /* Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = D0294DE61A93F37A00702856 /* Info.plist */; };
 		D0294DE81A93F39300702856 /* ATLMediaStreamTests.m in Sources */ = {isa = PBXBuildFile; fileRef = D0294DE41A93F37000702856 /* ATLMediaStreamTests.m */; };
+		D02CDCDB1A9FFC930013CBE8 /* ATLTestUtilities.m in Sources */ = {isa = PBXBuildFile; fileRef = D02CDCDA1A9FFC930013CBE8 /* ATLTestUtilities.m */; };
+		D02CDCDC1A9FFC930013CBE8 /* ATLTestUtilities.m in Sources */ = {isa = PBXBuildFile; fileRef = D02CDCDA1A9FFC930013CBE8 /* ATLTestUtilities.m */; };
+		D02CDCDD1A9FFC930013CBE8 /* ATLTestUtilities.m in Sources */ = {isa = PBXBuildFile; fileRef = D02CDCDA1A9FFC930013CBE8 /* ATLTestUtilities.m */; };
 		D04517141A9F9A0C00E137D9 /* ATLMediaAttachmentTests.m in Sources */ = {isa = PBXBuildFile; fileRef = D04517131A9F9A0C00E137D9 /* ATLMediaAttachmentTests.m */; };
 		D2575596FE7E9432B48A0D74 /* libPods-ProgrammaticTests.a in Frameworks */ = {isa = PBXBuildFile; fileRef = D82E912F9EB0D3AB8BD452A2 /* libPods-ProgrammaticTests.a */; };
 		D63C68E11A94250000D235D5 /* test-logo.png in Resources */ = {isa = PBXBuildFile; fileRef = D63C68DF1A94250000D235D5 /* test-logo.png */; };
@@ -116,6 +119,8 @@
 		D0294DD81A93F33900702856 /* UnitTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = UnitTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		D0294DE41A93F37000702856 /* ATLMediaStreamTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = ATLMediaStreamTests.m; path = Tests/ATLMediaStreamTests.m; sourceTree = "<group>"; };
 		D0294DE61A93F37A00702856 /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = Info.plist; path = Tests/Info.plist; sourceTree = "<group>"; };
+		D02CDCD91A9FFC930013CBE8 /* ATLTestUtilities.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ATLTestUtilities.h; sourceTree = "<group>"; };
+		D02CDCDA1A9FFC930013CBE8 /* ATLTestUtilities.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ATLTestUtilities.m; sourceTree = "<group>"; };
 		D04517131A9F9A0C00E137D9 /* ATLMediaAttachmentTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = ATLMediaAttachmentTests.m; path = Tests/ATLMediaAttachmentTests.m; sourceTree = "<group>"; };
 		D63C68DF1A94250000D235D5 /* test-logo.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "test-logo.png"; sourceTree = "<group>"; };
 		D6C045431A9914080028E9D0 /* ProgrammaticAppDelegate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = ProgrammaticAppDelegate.h; path = Examples/Programmatic/ProgrammaticAppDelegate.h; sourceTree = SOURCE_ROOT; };
@@ -375,6 +380,8 @@
 				D6F4060A1A8FDEEB00AE9581 /* ATLTestClasses.m */,
 				D6F4060B1A8FDEEB00AE9581 /* ATLTestInterface.h */,
 				D6F4060C1A8FDEEB00AE9581 /* ATLTestInterface.m */,
+				D02CDCD91A9FFC930013CBE8 /* ATLTestUtilities.h */,
+				D02CDCDA1A9FFC930013CBE8 /* ATLTestUtilities.m */,
 			);
 			name = Utilities;
 			sourceTree = "<group>";
@@ -809,6 +816,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				D02CDCDD1A9FFC930013CBE8 /* ATLTestUtilities.m in Sources */,
 				D0294DE81A93F39300702856 /* ATLMediaStreamTests.m in Sources */,
 				D04517141A9F9A0C00E137D9 /* ATLMediaAttachmentTests.m in Sources */,
 			);
@@ -824,6 +832,7 @@
 				D6F405CA1A8FDDE300AE9581 /* LYRQueryControllerMock.m in Sources */,
 				D6F405E91A8FDE3900AE9581 /* main.m in Sources */,
 				D6F405C51A8FDDE300AE9581 /* LYRClientMock.m in Sources */,
+				D02CDCDB1A9FFC930013CBE8 /* ATLTestUtilities.m in Sources */,
 				D6F405B01A8FDDAA00AE9581 /* ATLSampleConversationListViewController.m in Sources */,
 				D6F405C81A8FDDE300AE9581 /* LYRMessagePartMock.m in Sources */,
 				D6F405B21A8FDDAA00AE9581 /* ATLSampleParticipantTableViewController.m in Sources */,
@@ -862,6 +871,7 @@
 				D6D48F871A9D140F00C8872E /* LYRMessageMock.m in Sources */,
 				D6D48F881A9D140F00C8872E /* LYRMessagePartMock.m in Sources */,
 				D6D48F891A9D140F00C8872E /* LYRMockContentStore.m in Sources */,
+				D02CDCDC1A9FFC930013CBE8 /* ATLTestUtilities.m in Sources */,
 				D6D48F8A1A9D140F00C8872E /* LYRQueryControllerMock.m in Sources */,
 				D6D48F8B1A9D140F00C8872E /* ATLUserMock.m in Sources */,
 				D6D48F8C1A9D140F00C8872E /* ATLSampleConversationAvatarItem.m in Sources */,

--- a/Atlas.xcodeproj/project.pbxproj
+++ b/Atlas.xcodeproj/project.pbxproj
@@ -12,6 +12,7 @@
 		CE7BDC080170509511B89900 /* libPods-UnitTests.a in Frameworks */ = {isa = PBXBuildFile; fileRef = F7012754989ED85BE6A8D69E /* libPods-UnitTests.a */; };
 		D0294DE71A93F37A00702856 /* Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = D0294DE61A93F37A00702856 /* Info.plist */; };
 		D0294DE81A93F39300702856 /* ATLMediaStreamTests.m in Sources */ = {isa = PBXBuildFile; fileRef = D0294DE41A93F37000702856 /* ATLMediaStreamTests.m */; };
+		D04517141A9F9A0C00E137D9 /* ATLMediaAttachmentTests.m in Sources */ = {isa = PBXBuildFile; fileRef = D04517131A9F9A0C00E137D9 /* ATLMediaAttachmentTests.m */; };
 		D2575596FE7E9432B48A0D74 /* libPods-ProgrammaticTests.a in Frameworks */ = {isa = PBXBuildFile; fileRef = D82E912F9EB0D3AB8BD452A2 /* libPods-ProgrammaticTests.a */; };
 		D63C68E11A94250000D235D5 /* test-logo.png in Resources */ = {isa = PBXBuildFile; fileRef = D63C68DF1A94250000D235D5 /* test-logo.png */; };
 		D6A122B51A9D2CA2004F67BE /* ATLTestClasses.m in Sources */ = {isa = PBXBuildFile; fileRef = D6F4060A1A8FDEEB00AE9581 /* ATLTestClasses.m */; };
@@ -115,6 +116,7 @@
 		D0294DD81A93F33900702856 /* UnitTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = UnitTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		D0294DE41A93F37000702856 /* ATLMediaStreamTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = ATLMediaStreamTests.m; path = Tests/ATLMediaStreamTests.m; sourceTree = "<group>"; };
 		D0294DE61A93F37A00702856 /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = Info.plist; path = Tests/Info.plist; sourceTree = "<group>"; };
+		D04517131A9F9A0C00E137D9 /* ATLMediaAttachmentTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = ATLMediaAttachmentTests.m; path = Tests/ATLMediaAttachmentTests.m; sourceTree = "<group>"; };
 		D63C68DF1A94250000D235D5 /* test-logo.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "test-logo.png"; sourceTree = "<group>"; };
 		D6C045431A9914080028E9D0 /* ProgrammaticAppDelegate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = ProgrammaticAppDelegate.h; path = Examples/Programmatic/ProgrammaticAppDelegate.h; sourceTree = SOURCE_ROOT; };
 		D6C045441A9914080028E9D0 /* ProgrammaticAppDelegate.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = ProgrammaticAppDelegate.m; path = Examples/Programmatic/ProgrammaticAppDelegate.m; sourceTree = SOURCE_ROOT; };
@@ -264,6 +266,7 @@
 			isa = PBXGroup;
 			children = (
 				D0294DE41A93F37000702856 /* ATLMediaStreamTests.m */,
+				D04517131A9F9A0C00E137D9 /* ATLMediaAttachmentTests.m */,
 				D0294DE61A93F37A00702856 /* Info.plist */,
 			);
 			name = "Unit Tests";
@@ -807,6 +810,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				D0294DE81A93F39300702856 /* ATLMediaStreamTests.m in Sources */,
+				D04517141A9F9A0C00E137D9 /* ATLMediaAttachmentTests.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Code/Models/ATLMediaAttachment.m
+++ b/Code/Models/ATLMediaAttachment.m
@@ -90,7 +90,7 @@ static float const ATLMediaAttachmentDefaultThumbnailJPEGCompression = 0.5f;
     self = [super init];
     if (self) {
         if (!assetURL) {
-            @throw [NSException exceptionWithName:NSInternalInconsistencyException reason:[NSString stringWithFormat:@"Cannot initialize %@ with `nil` assetURL.", self.class] userInfo:nil];
+            @throw [NSException exceptionWithName:NSInternalInconsistencyException reason:[NSString stringWithFormat:@"Cannot initialize %@ with `nil` assetURL.", self.superclass] userInfo:nil];
         }
         _inputAssetURL = assetURL;
         self.thumbnailSize = thumbnailSize;
@@ -126,7 +126,8 @@ static float const ATLMediaAttachmentDefaultThumbnailJPEGCompression = 0.5f;
         // about the asset.
         // --------------------------------------------------------------------
         NSDictionary *imageMetadata = @{ @"width": @(asset.defaultRepresentation.dimensions.width),
-                                         @"height": @(asset.defaultRepresentation.dimensions.height) };
+                                         @"height": @(asset.defaultRepresentation.dimensions.height),
+                                         @"orientation": @(asset.defaultRepresentation.orientation) };
         NSError *JSONSerializerError;
         NSData *JSONData = [NSJSONSerialization dataWithJSONObject:imageMetadata options:NSJSONWritingPrettyPrinted error:&JSONSerializerError];
         if (JSONData) {
@@ -165,7 +166,7 @@ static float const ATLMediaAttachmentDefaultThumbnailJPEGCompression = 0.5f;
     self = [super init];
     if (self) {
         if (!image) {
-            @throw [NSException exceptionWithName:NSInternalInconsistencyException reason:[NSString stringWithFormat:@"Cannot initialize %@ with `nil` image.", self.class] userInfo:nil];
+            @throw [NSException exceptionWithName:NSInternalInconsistencyException reason:[NSString stringWithFormat:@"Cannot initialize %@ with `nil` image.", self.superclass] userInfo:nil];
         }
         self.inputImage = image;
         
@@ -188,7 +189,8 @@ static float const ATLMediaAttachmentDefaultThumbnailJPEGCompression = 0.5f;
         // about the asset.
         // --------------------------------------------------------------------
         NSDictionary *imageMetadata = @{ @"width": @(image.size.width),
-                                         @"height": @(image.size.height) };
+                                         @"height": @(image.size.height),
+                                         @"orientation": @(image.imageOrientation) };
         NSError *JSONSerializerError;
         NSData *JSONData = [NSJSONSerialization dataWithJSONObject:imageMetadata options:NSJSONWritingPrettyPrinted error:&JSONSerializerError];
         if (JSONData) {
@@ -230,12 +232,12 @@ static float const ATLMediaAttachmentDefaultThumbnailJPEGCompression = 0.5f;
     self = [super init];
     if (self) {
         if (!location) {
-            @throw [NSException exceptionWithName:NSInternalInconsistencyException reason:[NSString stringWithFormat:@"Cannot initialize %@ with `nil` location.", self.class] userInfo:nil];
+            @throw [NSException exceptionWithName:NSInternalInconsistencyException reason:[NSString stringWithFormat:@"Cannot initialize %@ with `nil` location.", self.superclass] userInfo:nil];
         }
         self.mediaType = ATLMediaAttachmentTypeLocation;
         self.mediaMIMEType = ATLMIMETypeLocation;
         NSData *data = [NSJSONSerialization dataWithJSONObject:@{ ATLLocationLatitudeKey: @(location.coordinate.latitude),
-                                                                  ATLLocationLongitudeKey:  @(location.coordinate.longitude) } options:0 error:nil];
+                                                                  ATLLocationLongitudeKey: @(location.coordinate.longitude) } options:0 error:nil];
         self.mediaInputStream = [NSInputStream inputStreamWithData:data];
         self.textRepresentation = @"Attachment: Location";
     }
@@ -251,7 +253,7 @@ static float const ATLMediaAttachmentDefaultThumbnailJPEGCompression = 0.5f;
     self = [super init];
     if (self) {
         if (!text) {
-            @throw [NSException exceptionWithName:NSInternalInconsistencyException reason:[NSString stringWithFormat:@"Cannot initialize %@ with `nil` text.", self.class] userInfo:nil];
+            @throw [NSException exceptionWithName:NSInternalInconsistencyException reason:[NSString stringWithFormat:@"Cannot initialize %@ with `nil` text.", self.superclass] userInfo:nil];
         }
         self.mediaType = ATLMediaAttachmentTypeText;
         self.mediaMIMEType = ATLMIMETypeTextPlain;
@@ -285,6 +287,17 @@ static float const ATLMediaAttachmentDefaultThumbnailJPEGCompression = 0.5f;
 + (instancetype)mediaAttachmentWithLocation:(CLLocation *)location
 {
     return [[ATLLocationMediaAttachment alloc] initWithLocation:location];
+}
+
+- (instancetype)init
+{
+    self = [super init];
+    if (self) {
+        if ([[self class] isEqual:[ATLMediaAttachment class]]) {
+            @throw [NSException exceptionWithName:NSInternalInconsistencyException reason:[NSString stringWithFormat:@"Failed to call designated initializer. Use one of the following initialiers: %@", [@[ NSStringFromSelector(@selector(mediaAttachmentWithAssetURL:thumbnailSize:)), NSStringFromSelector(@selector(mediaAttachmentWithImage:metadata:thumbnailSize:)), NSStringFromSelector(@selector(mediaAttachmentWithText:)), NSStringFromSelector(@selector(mediaAttachmentWithLocation:)) ] componentsJoinedByString:@", "]] userInfo:nil];
+        }
+    }
+    return self;
 }
 
 #pragma mark - NSTextAttachment Overrides

--- a/Code/Utilities/ATLMediaInputStream.m
+++ b/Code/Utilities/ATLMediaInputStream.m
@@ -125,7 +125,7 @@ static size_t ATLMediaInputStreamPutBytesIntoStreamCallback(void *assetStreamRef
     self = [super init];
     if (self) {
         if ([[self class] isEqual:[ATLMediaInputStream class]]) {
-            @throw [NSException exceptionWithName:NSInternalInconsistencyException reason:[NSString stringWithFormat:@"Failed to call designated initializer. Use one of the following initialiers: %@", [@[ NSStringFromSelector(@selector(mediaInputStreamWithAssetURL:)), NSStringFromSelector(@selector(mediaInputStreamWithImage:metadata:)) ] componentsJoinedByString:@","]] userInfo:nil];
+            @throw [NSException exceptionWithName:NSInternalInconsistencyException reason:[NSString stringWithFormat:@"Failed to call designated initializer. Use one of the following initialiers: %@", [@[ NSStringFromSelector(@selector(mediaInputStreamWithAssetURL:)), NSStringFromSelector(@selector(mediaInputStreamWithImage:metadata:)) ] componentsJoinedByString:@", "]] userInfo:nil];
         }
         _mediaStreamStatus = NSStreamStatusNotOpen;
         _mediaStreamError = nil;
@@ -472,7 +472,7 @@ static size_t ATLMediaInputStreamPutBytesIntoStreamCallback(void *assetStreamRef
         // If image should only be compressed.
         [destinationOptions setObject:@(self.compressionQuality) forKey:(NSString *)kCGImageDestinationLossyCompressionQuality];
     }
-    if (self.metadata && self.metadata[ATLMediaInputStreamAppleCameraTIFFOptionsKey]) {
+    if (self.metadata && self.metadata[ATLMediaInputStreamAppleCameraTIFFOptionsKey] && self.metadata[(NSString *)kCGImagePropertyOrientation]) {
         NSMutableDictionary *mutableTiffDict = [self.metadata[ATLMediaInputStreamAppleCameraTIFFOptionsKey] mutableCopy];
         [mutableTiffDict setObject:self.metadata[(NSString *)kCGImagePropertyOrientation] forKey:(NSString *)kCGImagePropertyTIFFOrientation];
         [destinationOptions setObject:mutableTiffDict forKey:ATLMediaInputStreamAppleCameraTIFFOptionsKey];

--- a/Tests/ATLMediaAttachmentTests.m
+++ b/Tests/ATLMediaAttachmentTests.m
@@ -1,0 +1,349 @@
+//
+//  ATLMediaAttachmentTests.m
+//  Atlas
+//
+//  Created by Klemen Verdnik on 2/26/15.
+//  Copyright (c) 2015 Layer, Inc. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+#import <UIKit/UIKit.h>
+#import <XCTest/XCTest.h>
+#import <AssetsLibrary/AssetsLibrary.h>
+#import "ATLMediaAttachment.h"
+
+#define EXP_SHORTHAND
+#import <Expecta/Expecta.h>
+#import <OCMock/OCMock.h>
+
+/**
+ @abstract Reads the stream content into a NSData object.
+ @param inputStream Input stream to read the content from.
+ @return Returns an `NSData` object containing the content of the stream; or `nil` in case of an error.
+ */
+NSData *ATLTestAttachmentDataFromStream(NSInputStream *inputStream);
+
+/**
+ @abstract Generates a test image with the given size.
+ @param size The size of the output image.
+ @return An `UIImage` instance.
+ */
+UIImage *ATLTestAttachmentMakeImageWithSize(CGSize size);
+
+/**
+ @abstract Synhchronously grabs the last photo from the Photos Library.
+ @param library The library to grab the last photo from.
+ @return Returns ALAsset instance of the last image located in the Photos Library, or `nil` in case of a failure.
+ */
+ALAsset *ATLTestAttachmentObtainLastImageFromAssetLibrary(ALAssetsLibrary *library);
+
+@interface ATLMediaAttachmentTests : XCTestCase
+
+@end
+
+@implementation ATLMediaAttachmentTests
+
+- (void)setUp
+{
+    [super setUp];
+}
+
+- (void)tearDown
+{
+    [super tearDown];
+}
+
+- (void)testMediaAttachmentInitFailures
+{
+    expect(^{
+        __unused ATLMediaAttachment *mediaAttachment = [[ATLMediaAttachment alloc] init];
+    }).to.raiseWithReason(NSInternalInconsistencyException, @"Failed to call designated initializer. Use one of the following initialiers: mediaAttachmentWithAssetURL:thumbnailSize:, mediaAttachmentWithImage:metadata:thumbnailSize:, mediaAttachmentWithText:, mediaAttachmentWithLocation:");
+    
+    expect(^{
+        __unused ATLMediaAttachment *mediaAttachment = [ATLMediaAttachment mediaAttachmentWithAssetURL:nil thumbnailSize:0];
+    }).to.raiseWithReason(NSInternalInconsistencyException, @"Cannot initialize ATLMediaAttachment with `nil` assetURL.");
+
+    expect(^{
+        __unused ATLMediaAttachment *mediaAttachment = [ATLMediaAttachment mediaAttachmentWithImage:nil metadata:nil thumbnailSize:0];
+    }).to.raiseWithReason(NSInternalInconsistencyException, @"Cannot initialize ATLMediaAttachment with `nil` image.");
+
+    expect(^{
+        __unused ATLMediaAttachment *mediaAttachment = [ATLMediaAttachment mediaAttachmentWithText:nil];
+    }).to.raiseWithReason(NSInternalInconsistencyException, @"Cannot initialize ATLMediaAttachment with `nil` text.");
+
+    expect(^{
+        __unused ATLMediaAttachment *mediaAttachment = [ATLMediaAttachment mediaAttachmentWithLocation:nil];
+    }).to.raiseWithReason(NSInternalInconsistencyException, @"Cannot initialize ATLMediaAttachment with `nil` location.");
+}
+
+- (void)testMediaAttachmentWithText
+{
+    ATLMediaAttachment *mediaAttachment = [ATLMediaAttachment mediaAttachmentWithText:@"What about the Noodle Incident?"];
+    
+    // Verifying properties
+    expect(mediaAttachment).toNot.beNil();
+    expect(NSStringFromClass(mediaAttachment.class)).to.equal(@"ATLTextMediaAttachment");
+    expect(mediaAttachment.textRepresentation).to.equal(@"What about the Noodle Incident?");
+    expect(mediaAttachment.thumbnailSize).to.equal(0);
+    expect(mediaAttachment.mediaMIMEType).to.equal(@"text/plain");
+    expect(mediaAttachment.mediaInputStream).toNot.beNil();
+    expect(mediaAttachment.mediaInputStream.streamStatus).to.equal(NSStreamStatusNotOpen);
+    expect(mediaAttachment.thumbnailMIMEType).to.beNil();
+    expect(mediaAttachment.thumbnailInputStream).to.beNil();
+    expect(mediaAttachment.metadataMIMEType).to.beNil();
+    expect(mediaAttachment.metadataInputStream).to.beNil();
+    
+    // Verifying stream content
+    NSData *payload = ATLTestAttachmentDataFromStream(mediaAttachment.mediaInputStream);
+    expect(payload).toNot.beNil();
+    expect(payload).to.equal([@"What about the Noodle Incident?" dataUsingEncoding:NSUTF8StringEncoding]);
+}
+
+- (void)testMediaAttachmentWithLocation
+{
+    CLLocation *location = [[CLLocation alloc] initWithLatitude:46.368383 longitude:15.106631];
+    ATLMediaAttachment *mediaAttachment = [ATLMediaAttachment mediaAttachmentWithLocation:location];
+    
+    // Verifying properties
+    expect(mediaAttachment).toNot.beNil();
+    expect(NSStringFromClass(mediaAttachment.class)).to.equal(@"ATLLocationMediaAttachment");
+    expect(mediaAttachment.textRepresentation).to.equal(@"Attachment: Location");
+    expect(mediaAttachment.thumbnailSize).to.equal(0);
+    expect(mediaAttachment.mediaMIMEType).to.equal(@"location/coordinate");
+    expect(mediaAttachment.mediaInputStream).toNot.beNil();
+    expect(mediaAttachment.mediaInputStream.streamStatus).to.equal(NSStreamStatusNotOpen);
+    expect(mediaAttachment.thumbnailMIMEType).to.beNil();
+    expect(mediaAttachment.thumbnailInputStream).to.beNil();
+    expect(mediaAttachment.metadataMIMEType).to.beNil();
+    expect(mediaAttachment.metadataInputStream).to.beNil();
+    
+    // Verifying stream content
+    NSData *payload = ATLTestAttachmentDataFromStream(mediaAttachment.mediaInputStream);
+    expect(payload).toNot.beNil();
+    expect(payload).to.equal([NSJSONSerialization dataWithJSONObject:@{ @"lat": @(location.coordinate.latitude), @"lon":  @(location.coordinate.longitude) }  options:0 error:nil]);
+}
+
+- (void)testMediaWithImage
+{
+    UIImage *image = ATLTestAttachmentMakeImageWithSize(CGSizeMake(1024, 512));
+    ATLMediaAttachment *mediaAttachment = [ATLMediaAttachment mediaAttachmentWithImage:image metadata:@{ @"Orientation": @(UIImageOrientationUp) } thumbnailSize:512];
+    
+    // Verifying properties
+    expect(mediaAttachment).toNot.beNil();
+    expect(NSStringFromClass(mediaAttachment.class)).to.equal(@"ATLImageMediaAttachment");
+    expect(mediaAttachment.textRepresentation).to.equal(@"Attachment: Image");
+    expect(mediaAttachment.thumbnailSize).to.equal(512);
+    expect(mediaAttachment.mediaMIMEType).to.equal(@"image/jpeg");
+    expect(mediaAttachment.mediaInputStream).toNot.beNil();
+    expect(mediaAttachment.mediaInputStream.streamStatus).to.equal(NSStreamStatusNotOpen);
+    expect(mediaAttachment.thumbnailMIMEType).to.equal(@"image/jpeg+preview");
+    expect(mediaAttachment.thumbnailInputStream).toNot.beNil();
+    expect(mediaAttachment.metadataMIMEType).to.equal(@"application/json+imageSize");
+    expect(mediaAttachment.metadataInputStream).toNot.beNil();
+    
+    // Verifying stream content
+    NSData *mediaPayload = ATLTestAttachmentDataFromStream(mediaAttachment.mediaInputStream);
+    expect(mediaPayload).toNot.beNil();
+    UIImage *processedImage = [UIImage imageWithData:mediaPayload];
+    expect(processedImage.size).to.equal(CGSizeMake(1024, 512));
+    expect(processedImage.imageOrientation).to.equal(UIImageOrientationUp);
+
+    // Verifying thumbnail content
+    NSData *thumbnailPayload = ATLTestAttachmentDataFromStream(mediaAttachment.thumbnailInputStream);
+    expect(thumbnailPayload).toNot.beNil();
+    processedImage = [UIImage imageWithData:thumbnailPayload];
+    expect(processedImage.size).to.equal(CGSizeMake(512, 256));
+    expect(processedImage.imageOrientation).to.equal(UIImageOrientationUp);
+    
+    // Verifying image metadata JSON
+    NSData *imageSizeMetadataJSON = ATLTestAttachmentDataFromStream(mediaAttachment.metadataInputStream);
+    expect(imageSizeMetadataJSON).toNot.beNil();
+    expect(imageSizeMetadataJSON).to.equal([NSJSONSerialization dataWithJSONObject:@{ @"width":@1024, @"height":@512, @"orientation":@(UIImageOrientationUp) } options:NSJSONWritingPrettyPrinted error:nil]);
+}
+
+- (void)testMediaWithAsset
+{
+    UIImage *image = ATLTestAttachmentMakeImageWithSize(CGSizeMake(1024, 512));
+
+    // First, save the generated image to the album.
+    ALAssetsLibrary *library = [[ALAssetsLibrary alloc] init];
+    __block NSURL *assetURL;
+    [library writeImageToSavedPhotosAlbum:image.CGImage metadata:@{ @"Orientation": @(UIImageOrientationUp) } completionBlock:^(NSURL *outAssetURL, NSError *error) {
+        assetURL = outAssetURL;
+    }];
+    expect(assetURL).willNot.beNil();
+    
+    ATLMediaAttachment *mediaAttachment = [ATLMediaAttachment mediaAttachmentWithAssetURL:assetURL thumbnailSize:512];
+    
+    // Verifying properties
+    expect(mediaAttachment).toNot.beNil();
+    expect(NSStringFromClass(mediaAttachment.class)).to.equal(@"ATLAssetMediaAttachment");
+    expect(mediaAttachment.textRepresentation).to.equal(@"Attachment: Image");
+    expect(mediaAttachment.thumbnailSize).to.equal(512);
+    expect(mediaAttachment.mediaMIMEType).to.equal(@"image/jpeg");
+    expect(mediaAttachment.mediaInputStream).toNot.beNil();
+    expect(mediaAttachment.mediaInputStream.streamStatus).to.equal(NSStreamStatusNotOpen);
+    expect(mediaAttachment.thumbnailMIMEType).to.equal(@"image/jpeg+preview");
+    expect(mediaAttachment.thumbnailInputStream).toNot.beNil();
+    expect(mediaAttachment.metadataMIMEType).to.equal(@"application/json+imageSize");
+    expect(mediaAttachment.metadataInputStream).toNot.beNil();
+    
+    // Verifying stream content
+    NSData *mediaPayload = ATLTestAttachmentDataFromStream(mediaAttachment.mediaInputStream);
+    expect(mediaPayload).toNot.beNil();
+    UIImage *processedImage = [UIImage imageWithData:mediaPayload];
+    expect(processedImage.size).to.equal(CGSizeMake(1024, 512));
+    expect(processedImage.imageOrientation).to.equal(UIImageOrientationUp);
+    
+    // Verifying thumbnail content
+    NSData *thumbnailPayload = ATLTestAttachmentDataFromStream(mediaAttachment.thumbnailInputStream);
+    expect(thumbnailPayload).toNot.beNil();
+    processedImage = [UIImage imageWithData:thumbnailPayload];
+    expect(processedImage.size).to.equal(CGSizeMake(512, 256));
+    expect(processedImage.imageOrientation).to.equal(UIImageOrientationUp);
+    
+    // Verifying image metadata JSON
+    NSData *imageSizeMetadataJSON = ATLTestAttachmentDataFromStream(mediaAttachment.metadataInputStream);
+    expect(imageSizeMetadataJSON).toNot.beNil();
+    expect(imageSizeMetadataJSON).to.equal([NSJSONSerialization dataWithJSONObject:@{ @"width":@1024, @"height":@512, @"orientation":@(UIImageOrientationUp) } options:NSJSONWritingPrettyPrinted error:nil]);
+}
+
+@end
+
+#pragma mark - Test utilities
+
+NSData *ATLTestAttachmentDataFromStream(NSInputStream *inputStream)
+{
+    if (!inputStream) {
+        @throw [NSException exceptionWithName:NSInvalidArgumentException reason:@"inputStream cannot be `nil`." userInfo:nil];
+    }
+    NSMutableData *dataFromStream = [NSMutableData data];
+    
+    // Open stream
+    [inputStream open];
+    if (inputStream.streamError) {
+        NSLog(@"Failed to stream image content with %@", inputStream.streamError);
+        return nil;
+    }
+    
+    // Start streaming
+    const NSUInteger bufferSize = 1024;
+    uint8_t *buffer = malloc(bufferSize);
+    NSUInteger bytesRead;
+    do {
+        bytesRead = [inputStream read:buffer maxLength:(unsigned long)bufferSize];
+        if (bytesRead != 0) {
+            [dataFromStream appendBytes:buffer length:bytesRead];
+        }
+    } while (bytesRead != 0);
+    free(buffer);
+    
+    // Close stream
+    [inputStream close];
+    
+    // Done
+    return dataFromStream;
+}
+
+UIImage *ATLTestAttachmentMakeImageWithSize(CGSize imageSize)
+{
+    CGFloat scaleFactor;
+    CGFloat xOffset = 0.0f;
+    CGFloat yOffset = 15.0f;
+    if (imageSize.width >= imageSize.height) {
+        scaleFactor = imageSize.height / 285;
+        xOffset = (imageSize.width / 2) - (580 / 2 * scaleFactor);
+    } else {
+        scaleFactor = imageSize.width / 580;
+        yOffset *= scaleFactor;
+        yOffset += (imageSize.height / 2) - (285 / 2 * scaleFactor);
+    }
+    
+    UIGraphicsBeginImageContext(imageSize);
+    CGContextRef context = UIGraphicsGetCurrentContext();
+    CGContextTranslateCTM(context, xOffset, yOffset);
+    CGContextScaleCTM(context, scaleFactor, scaleFactor);
+    
+    UIBezierPath* path = [UIBezierPath bezierPath];
+    [path setMiterLimit:4];
+    [[UIColor blackColor] setFill];
+    [path moveToPoint:CGPointMake(152.64, 175.83)];
+    [path addCurveToPoint:CGPointMake(143.64, 184.82) controlPoint1:CGPointMake(152.64, 180.7) controlPoint2:CGPointMake(148.52, 184.82)];
+    [path addLineToPoint:CGPointMake(120.88, 184.82)];
+    [path addCurveToPoint:CGPointMake(41.18, 105.13) controlPoint1:CGPointMake(72.94, 184.82) controlPoint2:CGPointMake(41.18, 153.06)];
+    [path addLineToPoint:CGPointMake(41.18, 82.36)];
+    [path addCurveToPoint:CGPointMake(50.17, 73.37) controlPoint1:CGPointMake(41.18, 77.48) controlPoint2:CGPointMake(45.3, 73.37)];
+    [path addLineToPoint:CGPointMake(143.64, 73.37)];
+    [path addCurveToPoint:CGPointMake(152.64, 82.36) controlPoint1:CGPointMake(148.52, 73.37) controlPoint2:CGPointMake(152.64, 77.48)];
+    [path addLineToPoint:CGPointMake(152.64, 175.83)];
+    [path closePath];
+    [path moveToPoint:CGPointMake(143.64, 57.19)];
+    [path addLineToPoint:CGPointMake(50.17, 57.19)];
+    [path addCurveToPoint:CGPointMake(25, 82.36) controlPoint1:CGPointMake(36.32, 57.19) controlPoint2:CGPointMake(25, 68.51)];
+    [path addLineToPoint:CGPointMake(25, 175.83)];
+    [path addCurveToPoint:CGPointMake(50.17, 201) controlPoint1:CGPointMake(25, 189.67) controlPoint2:CGPointMake(36.32, 201)];
+    [path addLineToPoint:CGPointMake(143.64, 201)];
+    [path addCurveToPoint:CGPointMake(168.81, 175.83) controlPoint1:CGPointMake(157.49, 201) controlPoint2:CGPointMake(168.81, 189.67)];
+    [path addLineToPoint:CGPointMake(168.81, 82.36)];
+    [path addCurveToPoint:CGPointMake(143.64, 57.19) controlPoint1:CGPointMake(168.81, 68.51) controlPoint2:CGPointMake(157.49, 57.19)];
+    [path closePath];
+    [path fill];
+    
+    CGRect frame = CGRectMake(178, 36.5, 504, 190);
+    NSString* text = [NSString stringWithFormat:@"%c%c%c%c%c", 76, 97, 121, 101, 114];
+    UIFont* font = [UIFont systemFontOfSize: 155];
+    [UIColor.blackColor setFill];
+    CGFloat height = frame.size.height;
+    [text drawInRect:CGRectMake(CGRectGetMinX(frame), CGRectGetMinY(frame) + (CGRectGetHeight(frame) - height) / 2, CGRectGetWidth(frame), height) withAttributes:@{ NSFontAttributeName: font }];
+
+    UIImage *image = UIGraphicsGetImageFromCurrentImageContext();
+    UIGraphicsEndImageContext();
+    
+    return image;
+}
+
+ALAsset *ATLTestAttachmentObtainLastImageFromAssetLibrary(ALAssetsLibrary *library)
+{
+    dispatch_semaphore_t semaphore = dispatch_semaphore_create(0);
+    dispatch_queue_t asyncQueue = dispatch_queue_create("com.layer.ATLMediaStreamTest.ObtainLastImage.async", DISPATCH_QUEUE_CONCURRENT);
+    
+    __block ALAsset *sourceAsset;
+    dispatch_async(asyncQueue, ^{
+        [library enumerateGroupsWithTypes:ALAssetsGroupSavedPhotos usingBlock:^(ALAssetsGroup *group, BOOL *stop) {
+            if (!group) {
+                *stop = YES;
+                dispatch_semaphore_signal(semaphore);
+                return;
+            }
+            [group setAssetsFilter:[ALAssetsFilter allPhotos]];
+            if ([group numberOfAssets] == 0) {
+                *stop = YES;
+                dispatch_semaphore_signal(semaphore);
+                return;
+            }
+            [group enumerateAssetsWithOptions:NSEnumerationReverse usingBlock:^(ALAsset *result, NSUInteger index, BOOL *innerStop) {
+                *innerStop = YES;
+                *stop = YES;
+                if (!result) {
+                    return;
+                }
+                sourceAsset = result;
+            }];
+        } failureBlock:^(NSError *error) {
+            dispatch_semaphore_signal(semaphore);
+        }];
+    });
+    dispatch_semaphore_wait(semaphore, DISPATCH_TIME_FOREVER);
+    return sourceAsset;
+}

--- a/Tests/ATLMediaAttachmentTests.m
+++ b/Tests/ATLMediaAttachmentTests.m
@@ -22,24 +22,11 @@
 #import <XCTest/XCTest.h>
 #import <AssetsLibrary/AssetsLibrary.h>
 #import "ATLMediaAttachment.h"
+#import "ATLTestUtilities.h"
 
 #define EXP_SHORTHAND
 #import <Expecta/Expecta.h>
 #import <OCMock/OCMock.h>
-
-/**
- @abstract Reads the stream content into a NSData object.
- @param inputStream Input stream to read the content from.
- @return Returns an `NSData` object containing the content of the stream; or `nil` in case of an error.
- */
-NSData *ATLTestAttachmentDataFromStream(NSInputStream *inputStream);
-
-/**
- @abstract Generates a test image with the given size.
- @param size The size of the output image.
- @return An `UIImage` instance.
- */
-UIImage *ATLTestAttachmentMakeImageWithSize(CGSize size);
 
 @interface ATLMediaAttachmentTests : XCTestCase
 
@@ -213,95 +200,3 @@ UIImage *ATLTestAttachmentMakeImageWithSize(CGSize size);
 }
 
 @end
-
-#pragma mark - Test utilities
-
-NSData *ATLTestAttachmentDataFromStream(NSInputStream *inputStream)
-{
-    if (!inputStream) {
-        @throw [NSException exceptionWithName:NSInvalidArgumentException reason:@"inputStream cannot be `nil`." userInfo:nil];
-    }
-    NSMutableData *dataFromStream = [NSMutableData data];
-    
-    // Open stream
-    [inputStream open];
-    if (inputStream.streamError) {
-        NSLog(@"Failed to stream image content with %@", inputStream.streamError);
-        return nil;
-    }
-    
-    // Start streaming
-    const NSUInteger bufferSize = 1024;
-    uint8_t *buffer = malloc(bufferSize);
-    NSUInteger bytesRead;
-    do {
-        bytesRead = [inputStream read:buffer maxLength:(unsigned long)bufferSize];
-        if (bytesRead != 0) {
-            [dataFromStream appendBytes:buffer length:bytesRead];
-        }
-    } while (bytesRead != 0);
-    free(buffer);
-    
-    // Close stream
-    [inputStream close];
-    
-    // Done
-    return dataFromStream;
-}
-
-UIImage *ATLTestAttachmentMakeImageWithSize(CGSize imageSize)
-{
-    CGFloat scaleFactor;
-    CGFloat xOffset = 0.0f;
-    CGFloat yOffset = 15.0f;
-    if (imageSize.width >= imageSize.height) {
-        scaleFactor = imageSize.height / 285;
-        xOffset = (imageSize.width / 2) - (580 / 2 * scaleFactor);
-    } else {
-        scaleFactor = imageSize.width / 580;
-        yOffset *= scaleFactor;
-        yOffset += (imageSize.height / 2) - (285 / 2 * scaleFactor);
-    }
-    
-    UIGraphicsBeginImageContext(imageSize);
-    CGContextRef context = UIGraphicsGetCurrentContext();
-    CGContextTranslateCTM(context, xOffset, yOffset);
-    CGContextScaleCTM(context, scaleFactor, scaleFactor);
-    
-    UIBezierPath* path = [UIBezierPath bezierPath];
-    [path setMiterLimit:4];
-    [[UIColor blackColor] setFill];
-    [path moveToPoint:CGPointMake(152.64, 175.83)];
-    [path addCurveToPoint:CGPointMake(143.64, 184.82) controlPoint1:CGPointMake(152.64, 180.7) controlPoint2:CGPointMake(148.52, 184.82)];
-    [path addLineToPoint:CGPointMake(120.88, 184.82)];
-    [path addCurveToPoint:CGPointMake(41.18, 105.13) controlPoint1:CGPointMake(72.94, 184.82) controlPoint2:CGPointMake(41.18, 153.06)];
-    [path addLineToPoint:CGPointMake(41.18, 82.36)];
-    [path addCurveToPoint:CGPointMake(50.17, 73.37) controlPoint1:CGPointMake(41.18, 77.48) controlPoint2:CGPointMake(45.3, 73.37)];
-    [path addLineToPoint:CGPointMake(143.64, 73.37)];
-    [path addCurveToPoint:CGPointMake(152.64, 82.36) controlPoint1:CGPointMake(148.52, 73.37) controlPoint2:CGPointMake(152.64, 77.48)];
-    [path addLineToPoint:CGPointMake(152.64, 175.83)];
-    [path closePath];
-    [path moveToPoint:CGPointMake(143.64, 57.19)];
-    [path addLineToPoint:CGPointMake(50.17, 57.19)];
-    [path addCurveToPoint:CGPointMake(25, 82.36) controlPoint1:CGPointMake(36.32, 57.19) controlPoint2:CGPointMake(25, 68.51)];
-    [path addLineToPoint:CGPointMake(25, 175.83)];
-    [path addCurveToPoint:CGPointMake(50.17, 201) controlPoint1:CGPointMake(25, 189.67) controlPoint2:CGPointMake(36.32, 201)];
-    [path addLineToPoint:CGPointMake(143.64, 201)];
-    [path addCurveToPoint:CGPointMake(168.81, 175.83) controlPoint1:CGPointMake(157.49, 201) controlPoint2:CGPointMake(168.81, 189.67)];
-    [path addLineToPoint:CGPointMake(168.81, 82.36)];
-    [path addCurveToPoint:CGPointMake(143.64, 57.19) controlPoint1:CGPointMake(168.81, 68.51) controlPoint2:CGPointMake(157.49, 57.19)];
-    [path closePath];
-    [path fill];
-    
-    CGRect frame = CGRectMake(178, 36.5, 504, 190);
-    NSString* text = [NSString stringWithFormat:@"%c%c%c%c%c", 76, 97, 121, 101, 114];
-    UIFont* font = [UIFont systemFontOfSize: 155];
-    [UIColor.blackColor setFill];
-    CGFloat height = frame.size.height;
-    [text drawInRect:CGRectMake(CGRectGetMinX(frame), CGRectGetMinY(frame) + (CGRectGetHeight(frame) - height) / 2, CGRectGetWidth(frame), height) withAttributes:@{ NSFontAttributeName: font }];
-
-    UIImage *image = UIGraphicsGetImageFromCurrentImageContext();
-    UIGraphicsEndImageContext();
-    
-    return image;
-}

--- a/Tests/ATLMediaStreamTests.m
+++ b/Tests/ATLMediaStreamTests.m
@@ -22,17 +22,11 @@
 #import <XCTest/XCTest.h>
 #import <AssetsLibrary/AssetsLibrary.h>
 #import "ATLMediaInputStream.h"
+#import "ATLTestUtilities.h"
 
 #define EXP_SHORTHAND
 #import <Expecta/Expecta.h>
 #import <OCMock/OCMock.h>
-
-/**
- @abstract Synhchronously grabs the last photo from the Photos Library.
- @param library The library to grab the last photo from.
- @return Returns ALAsset instance of the last image located in the Photos Library, or `nil` in case of a failure.
- */
-ALAsset *ATLAssetTestObtainLastImageFromAssetLibrary(ALAssetsLibrary *library);
 
 @interface ATLMediaStreamTest : XCTestCase
 
@@ -176,38 +170,3 @@ ALAsset *ATLAssetTestObtainLastImageFromAssetLibrary(ALAssetsLibrary *library);
 }
 
 @end
-
-ALAsset *ATLAssetTestObtainLastImageFromAssetLibrary(ALAssetsLibrary *library)
-{
-    dispatch_semaphore_t semaphore = dispatch_semaphore_create(0);
-    dispatch_queue_t asyncQueue = dispatch_queue_create("com.layer.ATLMediaStreamTest.ObtainLastImage.async", DISPATCH_QUEUE_CONCURRENT);
-    
-    __block ALAsset *sourceAsset;
-    dispatch_async(asyncQueue, ^{
-        [library enumerateGroupsWithTypes:ALAssetsGroupSavedPhotos usingBlock:^(ALAssetsGroup *group, BOOL *stop) {
-            if (!group) {
-                *stop = YES;
-                dispatch_semaphore_signal(semaphore);
-                return;
-            }
-            [group setAssetsFilter:[ALAssetsFilter allPhotos]];
-            if ([group numberOfAssets] == 0) {
-                *stop = YES;
-                dispatch_semaphore_signal(semaphore);
-                return;
-            }
-            [group enumerateAssetsWithOptions:NSEnumerationReverse usingBlock:^(ALAsset *result, NSUInteger index, BOOL *innerStop) {
-                *innerStop = YES;
-                *stop = YES;
-                if (!result) {
-                    return;
-                }
-                sourceAsset = result;
-            }];
-        } failureBlock:^(NSError *error) {
-            dispatch_semaphore_signal(semaphore);
-        }];
-    });
-    dispatch_semaphore_wait(semaphore, DISPATCH_TIME_FOREVER);
-    return sourceAsset;
-}

--- a/Tests/ATLMediaStreamTests.m
+++ b/Tests/ATLMediaStreamTests.m
@@ -27,54 +27,18 @@
 #import <Expecta/Expecta.h>
 #import <OCMock/OCMock.h>
 
-ALAsset *ATLAssetTestObtainLastImageFromAssetLibrary(ALAssetsLibrary *library)
-{
-    dispatch_semaphore_t semaphore = dispatch_semaphore_create(0);
-    dispatch_queue_t asyncQueue = dispatch_queue_create("com.layer.ATLMediaStreamTest.ObtainLastImage.async", DISPATCH_QUEUE_CONCURRENT);
-    
-    __block ALAsset *sourceAsset;
-    dispatch_async(asyncQueue, ^{
-        [library enumerateGroupsWithTypes:ALAssetsGroupSavedPhotos usingBlock:^(ALAssetsGroup *group, BOOL *stop) {
-            if (!group) {
-                *stop = YES;
-                dispatch_semaphore_signal(semaphore);
-                return;
-            }
-            [group setAssetsFilter:[ALAssetsFilter allPhotos]];
-            if ([group numberOfAssets] == 0) {
-                *stop = YES;
-                dispatch_semaphore_signal(semaphore);
-                return;
-            }
-            [group enumerateAssetsWithOptions:NSEnumerationReverse usingBlock:^(ALAsset *result, NSUInteger index, BOOL *innerStop) {
-                *innerStop = YES;
-                *stop = YES;
-                if (!result) {
-                    return;
-                }
-                sourceAsset = result;
-            }];
-        } failureBlock:^(NSError *error) {
-            dispatch_semaphore_signal(semaphore);
-        }];
-    });
-    dispatch_semaphore_wait(semaphore, DISPATCH_TIME_FOREVER);
-    return sourceAsset;
-}
+/**
+ @abstract Synhchronously grabs the last photo from the Photos Library.
+ @param library The library to grab the last photo from.
+ @return Returns ALAsset instance of the last image located in the Photos Library, or `nil` in case of a failure.
+ */
+ALAsset *ATLAssetTestObtainLastImageFromAssetLibrary(ALAssetsLibrary *library);
 
 @interface ATLMediaStreamTest : XCTestCase
 
 @end
 
 @implementation ATLMediaStreamTest
-
-- (void)setUp {
-    [super setUp];
-}
-
-- (void)tearDown {
-    [super tearDown];
-}
 
 - (void)testMediaStreamDesignatedInitFails
 {
@@ -212,3 +176,38 @@ ALAsset *ATLAssetTestObtainLastImageFromAssetLibrary(ALAssetsLibrary *library)
 }
 
 @end
+
+ALAsset *ATLAssetTestObtainLastImageFromAssetLibrary(ALAssetsLibrary *library)
+{
+    dispatch_semaphore_t semaphore = dispatch_semaphore_create(0);
+    dispatch_queue_t asyncQueue = dispatch_queue_create("com.layer.ATLMediaStreamTest.ObtainLastImage.async", DISPATCH_QUEUE_CONCURRENT);
+    
+    __block ALAsset *sourceAsset;
+    dispatch_async(asyncQueue, ^{
+        [library enumerateGroupsWithTypes:ALAssetsGroupSavedPhotos usingBlock:^(ALAssetsGroup *group, BOOL *stop) {
+            if (!group) {
+                *stop = YES;
+                dispatch_semaphore_signal(semaphore);
+                return;
+            }
+            [group setAssetsFilter:[ALAssetsFilter allPhotos]];
+            if ([group numberOfAssets] == 0) {
+                *stop = YES;
+                dispatch_semaphore_signal(semaphore);
+                return;
+            }
+            [group enumerateAssetsWithOptions:NSEnumerationReverse usingBlock:^(ALAsset *result, NSUInteger index, BOOL *innerStop) {
+                *innerStop = YES;
+                *stop = YES;
+                if (!result) {
+                    return;
+                }
+                sourceAsset = result;
+            }];
+        } failureBlock:^(NSError *error) {
+            dispatch_semaphore_signal(semaphore);
+        }];
+    });
+    dispatch_semaphore_wait(semaphore, DISPATCH_TIME_FOREVER);
+    return sourceAsset;
+}

--- a/Tests/ATLTestUtilities.h
+++ b/Tests/ATLTestUtilities.h
@@ -1,0 +1,44 @@
+//
+//  ATLTestUtilities.h
+//  Atlas
+//
+//  Created by Klemen Verdnik on 2/26/15.
+//  Copyright (c) 2015 Layer. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+#import <Foundation/Foundation.h>
+#import <UIKit/UIKit.h>
+#import <AssetsLibrary/AssetsLibrary.h>
+
+/**
+ @abstract Reads the stream content into a NSData object.
+ @param inputStream Input stream to read the content from.
+ @return Returns an `NSData` object containing the content of the stream; or `nil` in case of an error.
+ */
+NSData *ATLTestAttachmentDataFromStream(NSInputStream *inputStream);
+
+/**
+ @abstract Generates a test image with the given size.
+ @param size The size of the output image.
+ @return An `UIImage` instance.
+ */
+UIImage *ATLTestAttachmentMakeImageWithSize(CGSize size);
+
+/**
+ @abstract Synhchronously grabs the last photo from the Photos Library.
+ @param library The library to grab the last photo from.
+ @return Returns ALAsset instance of the last image located in the Photos Library, or `nil` in case of a failure.
+ */
+ALAsset *ATLAssetTestObtainLastImageFromAssetLibrary(ALAssetsLibrary *library);

--- a/Tests/ATLTestUtilities.m
+++ b/Tests/ATLTestUtilities.m
@@ -1,0 +1,146 @@
+//
+//  ATLTestUtilities.m
+//  Atlas
+//
+//  Created by Klemen Verdnik on 2/26/15.
+//  Copyright (c) 2015 Layer. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+#import "ATLTestUtilities.h"
+
+NSData *ATLTestAttachmentDataFromStream(NSInputStream *inputStream)
+{
+    if (!inputStream) {
+        @throw [NSException exceptionWithName:NSInvalidArgumentException reason:@"inputStream cannot be `nil`." userInfo:nil];
+    }
+    NSMutableData *dataFromStream = [NSMutableData data];
+    
+    // Open stream
+    [inputStream open];
+    if (inputStream.streamError) {
+        NSLog(@"Failed to stream image content with %@", inputStream.streamError);
+        return nil;
+    }
+    
+    // Start streaming
+    const NSUInteger bufferSize = 1024;
+    uint8_t *buffer = malloc(bufferSize);
+    NSUInteger bytesRead;
+    do {
+        bytesRead = [inputStream read:buffer maxLength:(unsigned long)bufferSize];
+        if (bytesRead != 0) {
+            [dataFromStream appendBytes:buffer length:bytesRead];
+        }
+    } while (bytesRead != 0);
+    free(buffer);
+    
+    // Close stream
+    [inputStream close];
+    
+    // Done
+    return dataFromStream;
+}
+
+UIImage *ATLTestAttachmentMakeImageWithSize(CGSize imageSize)
+{
+    CGFloat scaleFactor;
+    CGFloat xOffset = 0.0f;
+    CGFloat yOffset = 15.0f;
+    if (imageSize.width >= imageSize.height) {
+        scaleFactor = imageSize.height / 285;
+        xOffset = (imageSize.width / 2) - (580 / 2 * scaleFactor);
+    } else {
+        scaleFactor = imageSize.width / 580;
+        yOffset *= scaleFactor;
+        yOffset += (imageSize.height / 2) - (285 / 2 * scaleFactor);
+    }
+    
+    UIGraphicsBeginImageContext(imageSize);
+    CGContextRef context = UIGraphicsGetCurrentContext();
+    CGContextTranslateCTM(context, xOffset, yOffset);
+    CGContextScaleCTM(context, scaleFactor, scaleFactor);
+    
+    UIBezierPath* path = [UIBezierPath bezierPath];
+    [path setMiterLimit:4];
+    [[UIColor blackColor] setFill];
+    [path moveToPoint:CGPointMake(152.64, 175.83)];
+    [path addCurveToPoint:CGPointMake(143.64, 184.82) controlPoint1:CGPointMake(152.64, 180.7) controlPoint2:CGPointMake(148.52, 184.82)];
+    [path addLineToPoint:CGPointMake(120.88, 184.82)];
+    [path addCurveToPoint:CGPointMake(41.18, 105.13) controlPoint1:CGPointMake(72.94, 184.82) controlPoint2:CGPointMake(41.18, 153.06)];
+    [path addLineToPoint:CGPointMake(41.18, 82.36)];
+    [path addCurveToPoint:CGPointMake(50.17, 73.37) controlPoint1:CGPointMake(41.18, 77.48) controlPoint2:CGPointMake(45.3, 73.37)];
+    [path addLineToPoint:CGPointMake(143.64, 73.37)];
+    [path addCurveToPoint:CGPointMake(152.64, 82.36) controlPoint1:CGPointMake(148.52, 73.37) controlPoint2:CGPointMake(152.64, 77.48)];
+    [path addLineToPoint:CGPointMake(152.64, 175.83)];
+    [path closePath];
+    [path moveToPoint:CGPointMake(143.64, 57.19)];
+    [path addLineToPoint:CGPointMake(50.17, 57.19)];
+    [path addCurveToPoint:CGPointMake(25, 82.36) controlPoint1:CGPointMake(36.32, 57.19) controlPoint2:CGPointMake(25, 68.51)];
+    [path addLineToPoint:CGPointMake(25, 175.83)];
+    [path addCurveToPoint:CGPointMake(50.17, 201) controlPoint1:CGPointMake(25, 189.67) controlPoint2:CGPointMake(36.32, 201)];
+    [path addLineToPoint:CGPointMake(143.64, 201)];
+    [path addCurveToPoint:CGPointMake(168.81, 175.83) controlPoint1:CGPointMake(157.49, 201) controlPoint2:CGPointMake(168.81, 189.67)];
+    [path addLineToPoint:CGPointMake(168.81, 82.36)];
+    [path addCurveToPoint:CGPointMake(143.64, 57.19) controlPoint1:CGPointMake(168.81, 68.51) controlPoint2:CGPointMake(157.49, 57.19)];
+    [path closePath];
+    [path fill];
+    
+    CGRect frame = CGRectMake(178, 36.5, 504, 190);
+    NSString* text = [NSString stringWithFormat:@"%c%c%c%c%c", 76, 97, 121, 101, 114];
+    UIFont* font = [UIFont systemFontOfSize: 155];
+    [UIColor.blackColor setFill];
+    CGFloat height = frame.size.height;
+    [text drawInRect:CGRectMake(CGRectGetMinX(frame), CGRectGetMinY(frame) + (CGRectGetHeight(frame) - height) / 2, CGRectGetWidth(frame), height) withAttributes:@{ NSFontAttributeName: font }];
+    
+    UIImage *image = UIGraphicsGetImageFromCurrentImageContext();
+    UIGraphicsEndImageContext();
+    
+    return image;
+}
+
+ALAsset *ATLAssetTestObtainLastImageFromAssetLibrary(ALAssetsLibrary *library)
+{
+    dispatch_semaphore_t semaphore = dispatch_semaphore_create(0);
+    dispatch_queue_t asyncQueue = dispatch_queue_create("com.layer.ATLMediaStreamTest.ObtainLastImage.async", DISPATCH_QUEUE_CONCURRENT);
+    
+    __block ALAsset *sourceAsset;
+    dispatch_async(asyncQueue, ^{
+        [library enumerateGroupsWithTypes:ALAssetsGroupSavedPhotos usingBlock:^(ALAssetsGroup *group, BOOL *stop) {
+            if (!group) {
+                *stop = YES;
+                dispatch_semaphore_signal(semaphore);
+                return;
+            }
+            [group setAssetsFilter:[ALAssetsFilter allPhotos]];
+            if ([group numberOfAssets] == 0) {
+                *stop = YES;
+                dispatch_semaphore_signal(semaphore);
+                return;
+            }
+            [group enumerateAssetsWithOptions:NSEnumerationReverse usingBlock:^(ALAsset *result, NSUInteger index, BOOL *innerStop) {
+                *innerStop = YES;
+                *stop = YES;
+                if (!result) {
+                    return;
+                }
+                sourceAsset = result;
+            }];
+        } failureBlock:^(NSError *error) {
+            dispatch_semaphore_signal(semaphore);
+        }];
+    });
+    dispatch_semaphore_wait(semaphore, DISPATCH_TIME_FOREVER);
+    return sourceAsset;
+}


### PR DESCRIPTION
Fixes the crash where trying to initialize `ATLMessageCollectionViewCell` with a frame that has a `NaN` value for height.

Android sample app doesn't yet send multipart messages (with thumbnails and image size info) along with the full resolution photos.