### PR TITLE
Allow title & color customization of conversation delete buttons

### DIFF
--- a/Code/Controllers/ATLConversationListViewController.h
+++ b/Code/Controllers/ATLConversationListViewController.h
@@ -95,20 +95,18 @@
 /**
  @abstract Asks the data source for a string to display on the delete button for a given conversation and deletion mode.
  @param conversationListViewController The `LYRConversationListViewController` in which the button title will appear.
- @param conversation The `LYRConversation` object.
  @param deletionMode The `LYRDeletionMode` for which a button has to be displayed.
  @return The string to be displayed on the delete button for a given conversation in the conversation list.
  */
-- (NSString *)conversationListViewController:(ATLConversationListViewController *)conversationListViewController deleteActionStringForConversation:(LYRConversation *)conversation deletionMode:(LYRDeletionMode)deletionMode;
+- (NSString *)conversationListViewController:(ATLConversationListViewController *)conversationListViewController textForButtonWithDeletionMode:(LYRDeletionMode)deletionMode;
 
 /**
  @abstract Asks the data source for a color to apply to the delete button for a given conversation and deletion mode.
  @param conversationListViewController The `LYRConversationListViewController` in which the button title will appear.
- @param conversation The `LYRConversation` object.
  @param deletionMode The `LYRDeletionMode` for which a button has to be displayed.
  @return The color to apply on the delete button for a given conversation in the conversation list.
  */
-- (UIColor *)conversationListViewController:(ATLConversationListViewController *)conversationListViewController deleteActionColorForConversation:(LYRConversation *)conversation deletionMode:(LYRDeletionMode)deletionMode;
+- (UIColor *)conversationListViewController:(ATLConversationListViewController *)conversationListViewController colorForButtonWithDeletionMode:(LYRDeletionMode)deletionMode;
 
 @end
 

--- a/Code/Controllers/ATLConversationListViewController.h
+++ b/Code/Controllers/ATLConversationListViewController.h
@@ -92,6 +92,24 @@
  */
 - (id<ATLAvatarItem>)conversationListViewController:(ATLConversationListViewController *)conversationListViewController avatarItemForConversation:(LYRConversation *)conversation;
 
+/**
+ @abstract Asks the data source for a string to display on the delete button for a given conversation and deletion mode.
+ @param conversationListViewController The `LYRConversationListViewController` in which the button title will appear.
+ @param conversation The `LYRConversation` object.
+ @param deletionMode The `LYRDeletionMode` for which a button has to be displayed.
+ @return The string to be displayed on the delete button for a given conversation in the conversation list.
+ */
+- (NSString *)conversationListViewController:(ATLConversationListViewController *)conversationListViewController deleteActionStringForConversation:(LYRConversation *)conversation deletionMode:(LYRDeletionMode)deletionMode;
+
+/**
+ @abstract Asks the data source for a color to apply to the delete button for a given conversation and deletion mode.
+ @param conversationListViewController The `LYRConversationListViewController` in which the button title will appear.
+ @param conversation The `LYRConversation` object.
+ @param deletionMode The `LYRDeletionMode` for which a button has to be displayed.
+ @return The color to apply on the delete button for a given conversation in the conversation list.
+ */
+- (UIColor *)conversationListViewController:(ATLConversationListViewController *)conversationListViewController deleteActionColorForConversation:(LYRConversation *)conversation deletionMode:(LYRDeletionMode)deletionMode;
+
 @end
 
 /**

--- a/Code/Controllers/ATLConversationListViewController.m
+++ b/Code/Controllers/ATLConversationListViewController.m
@@ -274,8 +274,8 @@ NSString *const ATLConversationTableViewAccessibilityIdentifier = @"Conversation
     for (NSNumber *deletionMode in self.deletionModes) {
         NSString *actionString;
         UIColor *actionColor;
-        if ([self.dataSource respondsToSelector:@selector(conversationListViewController:deleteActionStringForConversation:deletionMode:)]) {
-            actionString = [self.dataSource conversationListViewController:self deleteActionStringForConversation:conversation deletionMode:deletionMode.integerValue];
+        if ([self.dataSource respondsToSelector:@selector(conversationListViewController:textForButtonWithDeletionMode:)]) {
+            actionString = [self.dataSource conversationListViewController:self textForButtonWithDeletionMode:deletionMode.integerValue];
         } else {
             switch (deletionMode.integerValue) {
                 case LYRDeletionModeLocal:
@@ -288,8 +288,8 @@ NSString *const ATLConversationTableViewAccessibilityIdentifier = @"Conversation
                     break;
             }
         }
-        if ([self.dataSource respondsToSelector:@selector(conversationListViewController:deleteActionColorForConversation:deletionMode:)]) {
-            actionColor = [self.dataSource conversationListViewController:self deleteActionColorForConversation:conversation deletionMode:deletionMode.integerValue];
+        if ([self.dataSource respondsToSelector:@selector(conversationListViewController:colorForButtonWithDeletionMode:)]) {
+            actionColor = [self.dataSource conversationListViewController:self colorForButtonWithDeletionMode:deletionMode.integerValue];
         } else {
             switch (deletionMode.integerValue) {
                 case LYRDeletionModeLocal:

--- a/Code/Controllers/ATLConversationListViewController.m
+++ b/Code/Controllers/ATLConversationListViewController.m
@@ -269,22 +269,38 @@ NSString *const ATLConversationTableViewAccessibilityIdentifier = @"Conversation
 
 - (NSArray *)tableView:(UITableView *)tableView editActionsForRowAtIndexPath:(NSIndexPath *)indexPath
 {
+    LYRConversation *conversation = [self.queryController objectAtIndexPath:indexPath];
     NSMutableArray *actions = [NSMutableArray new];
     for (NSNumber *deletionMode in self.deletionModes) {
         NSString *actionString;
         UIColor *actionColor;
-        switch (deletionMode.integerValue) {
-            case LYRDeletionModeLocal:
-                actionString = @"Local";
-                actionColor = [UIColor redColor];
-                break;
-            case LYRDeletionModeAllParticipants:
-                actionString = @"Global";
-                actionColor = [UIColor grayColor];
-                break;
-
-            default:
-                break;
+        if ([self.dataSource respondsToSelector:@selector(conversationListViewController:deleteActionStringForConversation:deletionMode:)]) {
+            actionString = [self.dataSource conversationListViewController:self deleteActionStringForConversation:conversation deletionMode:deletionMode.integerValue];
+        } else {
+            switch (deletionMode.integerValue) {
+                case LYRDeletionModeLocal:
+                    actionString = @"Local";
+                    break;
+                case LYRDeletionModeAllParticipants:
+                    actionString = @"Global";
+                    break;
+                default:
+                    break;
+            }
+        }
+        if ([self.dataSource respondsToSelector:@selector(conversationListViewController:deleteActionColorForConversation:deletionMode:)]) {
+            actionColor = [self.dataSource conversationListViewController:self deleteActionColorForConversation:conversation deletionMode:deletionMode.integerValue];
+        } else {
+            switch (deletionMode.integerValue) {
+                case LYRDeletionModeLocal:
+                    actionColor = [UIColor redColor];
+                    break;
+                case LYRDeletionModeAllParticipants:
+                    actionColor = [UIColor grayColor];
+                    break;
+                default:
+                    break;
+            }
         }
         UITableViewRowAction *deleteAction = [UITableViewRowAction rowActionWithStyle:UITableViewRowActionStyleDefault title:actionString handler:^(UITableViewRowAction *action, NSIndexPath *indexPath) {
             [self deleteConversationAtIndexPath:indexPath withDeletionMode:deletionMode.integerValue];


### PR DESCRIPTION
Choosing which delete buttons are visible is easily done by setting `deletionModes`.

But I found myself with the need to customize the title of the delete button, which is currently hardcoded to either "Local" or "Global".

I don't know if datasource methods are the best pattern for this feature, but they do the job and are flexible enough for any kind of usecase: different titles for each conversations/deletion modes, i18n, etc.

Implementation looks like this (Swift):
```swift
/**
Atlas - Returns a string to be displayed on the delete button.
*/
func conversationListViewController(conversationListViewController: ATLConversationListViewController!, deleteActionStringForConversation conversation: LYRConversation!, deletionMode: LYRDeletionMode) -> String! {
    // Use conversation & deletionMode params to determine what title to return
    return "Delete"
}

/**
Atlas - Returns a color to apply on the delete button.
*/
func conversationListViewController(conversationListViewController: ATLConversationListViewController!, deleteActionColorForConversation conversation: LYRConversation!, deletionMode: LYRDeletionMode) -> UIColor! {
    // Use conversation & deletionMode params to determine what color to return
    return UIColor.redColor()
}
```
