### PR TITLE
Forcing layout of collection view to prevent animation. Fixes #749

### DIFF
--- a/Code/Controllers/ATLBaseConversationViewController.m
+++ b/Code/Controllers/ATLBaseConversationViewController.m
@@ -127,7 +127,6 @@ static CGFloat const ATLMaxScrollDistanceFromBottom = 150;
     }
 }
 
-
 - (void)viewWillDisappear:(BOOL)animated
 {
     [super viewWillDisappear:animated];

--- a/Code/Controllers/ATLConversationViewController.m
+++ b/Code/Controllers/ATLConversationViewController.m
@@ -136,6 +136,9 @@ static NSString *const ATLPushNotificationSoundName = @"layerbell.caf";
         [self configureAddressBarForConversation];
     }
     self.canDisableAddressBar = YES;
+    if (!self.hasAppeared) {
+        [self.collectionView layoutIfNeeded];
+    }
 }
 
 - (void)viewDidAppear:(BOOL)animated

--- a/Code/Controllers/ATLTypingIndicatorViewController.m
+++ b/Code/Controllers/ATLTypingIndicatorViewController.m
@@ -164,7 +164,6 @@
     return fittedSize.width <= CGRectGetWidth(label.frame);
 }
 
-
 - (void)configureToLabelConstraints
 {
     [self.view addConstraint:[NSLayoutConstraint constraintWithItem:_label attribute:NSLayoutAttributeLeft relatedBy:NSLayoutRelationEqual toItem:self.view attribute:NSLayoutAttributeLeft multiplier:1.0 constant:8]];


### PR DESCRIPTION
This PR forces the Collection View to layout it's subviews before coming on screen. It prevents an awkward animation if pushing the collection view on screen without animation. 