### PR TITLE
Allow hiding edit button & search bar in conversations list

### DIFF
--- a/Code/Controllers/ATLConversationListViewController.h
+++ b/Code/Controllers/ATLConversationListViewController.h
@@ -169,6 +169,16 @@
 @property (nonatomic, assign) BOOL allowsEditing;
 
 /**
+ @abstract IA boolean value to determine whether or not the receiver should display an Edit button made available with `allowsEditing`. Default is yes.
+  */
+@property (nonatomic, assign) BOOL displaysEditButton;
+
+/**
+ @abstract IA boolean value to determine whether or not the receiver should display a `UISearchBar` at the top of the list. Default is yes.
+ */
+@property (nonatomic) BOOL displaysSearchBar;
+
+/**
  @abstract Sets the height for cells within the receiver.
  @default `76.0`
  @raises NSInternalInconsistencyException Raised if the value is mutated after the receiver has been presented.


### PR DESCRIPTION
- `displaysEditButton` can be toggled before & after the view is loaded.
- `displaysSearchBar ` can only be configured before the view is loaded (mimicking `displaysAddressBar` from `ATLBaseConversationViewController`).