### PR TITLE
Fix default value for displaysAddressBar, as per documentation

### DIFF
--- a/Code/Controllers/ATLBaseConversationViewController.m
+++ b/Code/Controllers/ATLBaseConversationViewController.m
@@ -59,7 +59,6 @@ static CGFloat const ATLMaxScrollDistanceFromBottom = 150;
     _displaysAddressBar = NO;
     _typingParticipantIDs = [NSMutableArray new];
     _firstAppearance = YES;
-    _displaysAddressBar = YES;
 }
 
 - (void)loadView


### PR DESCRIPTION
As per documentation, displaysAddressBar should default to `NO`.
The superfluous `_displaysAddressBar = YES` is now removed.