### PR TITLE
Making Atlas compatible with LayerKit v0.11.0

### DIFF
--- a/Atlas.podspec
+++ b/Atlas.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name                        = "Atlas"
-  s.version                     = '1.0.1'
+  s.version                     = '1.0.2'
   s.summary                     = "Atlas is a library of communications user interface components integrated with LayerKit."
   s.homepage                    = 'https://atlas.layer.com/'
   s.social_media_url            = 'http://twitter.com/layer'
@@ -18,5 +18,5 @@ Pod::Spec.new do |s|
   s.header_mappings_dir         = 'Code'
   s.ios.frameworks              = %w{UIKit CoreLocation MobileCoreServices}
   s.ios.deployment_target       = '7.0'
-  s.dependency                  'LayerKit', '>= 0.10.3'
+  s.dependency                  'LayerKit', '>= 0.11.0'
 end

--- a/Code/Atlas.m
+++ b/Code/Atlas.m
@@ -20,4 +20,4 @@
 
 #import "Atlas.h"
 
-NSString *const ATLVersionString = @"1.0.1";
+NSString *const ATLVersionString = @"1.0.2";

--- a/Code/Models/ATLConversationDataSource.m
+++ b/Code/Models/ATLConversationDataSource.m
@@ -42,7 +42,7 @@ NSInteger const ATLQueryControllerPaginationWindow = 30;
     if (self) {
         LYRQuery *query = [LYRQuery queryWithClass:[LYRMessage class]];
         query.predicate = [LYRPredicate predicateWithProperty:@"conversation" operator:LYRPredicateOperatorIsEqualTo value:conversation];
-        query.sortDescriptors = @[[NSSortDescriptor sortDescriptorWithKey:@"index" ascending:YES]];
+        query.sortDescriptors = @[[NSSortDescriptor sortDescriptorWithKey:@"position" ascending:YES]];
        
         NSUInteger numberOfMessagesAvailable = [layerClient countForQuery:query error:nil];
         NSUInteger numberOfMessagesToDisplay = MIN(numberOfMessagesAvailable, ATLQueryControllerPaginationWindow);


### PR DESCRIPTION
LayerKit's `message.index` property has been replaced by `message.position`.