### PR TITLE
Feature/message input toolbar customization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 ## 1.0.4
 
-###Public API Changes
+### Public API Changes
+
 * Moved `searchController` property to public API on `ATLConversationListViewController`. 
 * Moved `UIImagePickerControllerDelegate` and `UINavigationControllerDelegate` declarations to header of `ATLConversationViewController`.
 * Added `leftAccessoryImage`, `rightAccessoryImage` and `displaysRightAccessoryImage` to `ATLMessageInputToolbar`. 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Atlas Changelog
 
+## 1.0.4
+
+###Public API Changes
+* Moved `searchController` property to public API on `ATLConversationListViewController`. 
+* Moved `UIImagePickerControllerDelegate` and `UINavigationControllerDelegate` declarations to header of `ATLConversationViewController`.
+* Added `leftAccessoryImage`, `rightAccessoryImage` and `displaysRightAccessoryImage` to `ATLMessageInputToolbar`. 
+
 ## 1.0.3
 
 ### Enhancements

--- a/Code/Controllers/ATLConversationListViewController.h
+++ b/Code/Controllers/ATLConversationListViewController.h
@@ -114,7 +114,7 @@
  @abstract The `ATLConversationListViewController` class presents an interface which provides
  for the display and selection of Layer conversations.
  */
-@interface ATLConversationListViewController : UITableViewController
+@interface ATLConversationListViewController : UITableViewController <UISearchBarDelegate, UISearchControllerDelegate, UISearchDisplayDelegate>
 
 ///-------------------------------------------------------
 /// @name Initializing a Conversation List View Controller
@@ -204,5 +204,21 @@
  @param conversation The Conversation object to reload the corresponding cell of. Cannot be `nil`.
  */
 - (void)reloadCellForConversation:(LYRConversation *)conversation;
+
+///--------------------------
+/// @name Conversation Search
+///--------------------------
+
+/**
+ @abstract The search display controller used to display conversation search results.
+ @raises NSInternalInconsistencyException Raised if the value is mutated after the receiver has been presented.
+ */
+@property (nonatomic) UISearchDisplayController *searchController;
+
+/**
+ @abstract The search bar displayed above the conversation list.
+ @raises NSInternalInconsistencyException Raised if the value is mutated after the receiver has been presented.
+ */
+@property (nonatomic) UISearchBar *searchBar;
 
 @end

--- a/Code/Controllers/ATLConversationListViewController.h
+++ b/Code/Controllers/ATLConversationListViewController.h
@@ -114,7 +114,7 @@
  @abstract The `ATLConversationListViewController` class presents an interface which provides
  for the display and selection of Layer conversations.
  */
-@interface ATLConversationListViewController : UITableViewController <UISearchBarDelegate, UISearchControllerDelegate, UISearchDisplayDelegate>
+@interface ATLConversationListViewController : UITableViewController
 
 ///-------------------------------------------------------
 /// @name Initializing a Conversation List View Controller
@@ -195,6 +195,16 @@
  */
 @property (nonatomic, assign) CGFloat rowHeight;
 
+///-------------
+/// @name Search
+///-------------
+
+/**
+ @abstract The controller used to display search results.
+ */
+@property (nonatomic, readonly) UISearchDisplayController *searchContorller;
+
+
 ///------------------------------
 /// @name Reloading Conversations
 ///------------------------------
@@ -204,21 +214,5 @@
  @param conversation The Conversation object to reload the corresponding cell of. Cannot be `nil`.
  */
 - (void)reloadCellForConversation:(LYRConversation *)conversation;
-
-///--------------------------
-/// @name Conversation Search
-///--------------------------
-
-/**
- @abstract The search display controller used to display conversation search results.
- @raises NSInternalInconsistencyException Raised if the value is mutated after the receiver has been presented.
- */
-@property (nonatomic) UISearchDisplayController *searchController;
-
-/**
- @abstract The search bar displayed above the conversation list.
- @raises NSInternalInconsistencyException Raised if the value is mutated after the receiver has been presented.
- */
-@property (nonatomic) UISearchBar *searchBar;
 
 @end

--- a/Code/Controllers/ATLConversationListViewController.m
+++ b/Code/Controllers/ATLConversationListViewController.m
@@ -23,12 +23,14 @@
 
 static NSString *const ATLConversationCellReuseIdentifier = @"ATLConversationCellReuseIdentifier";
 
-@interface ATLConversationListViewController () <UIActionSheetDelegate, LYRQueryControllerDelegate>
+@interface ATLConversationListViewController () <UIActionSheetDelegate, LYRQueryControllerDelegate, UISearchBarDelegate, UISearchControllerDelegate, UISearchDisplayDelegate>
 
 @property (nonatomic) LYRQueryController *queryController;
 @property (nonatomic) LYRQueryController *searchQueryController;
 @property (nonatomic) LYRConversation *conversationToDelete;
 @property (nonatomic) LYRConversation *conversationSelectedBeforeContentChange;
+@property (nonatomic, readwrite) UISearchDisplayController *searchController;
+@property (nonatomic) UISearchBar *searchBar;
 @property (nonatomic) BOOL hasAppeared;
 
 @end
@@ -195,22 +197,6 @@ NSString *const ATLConversationTableViewAccessibilityIdentifier = @"Conversation
         @throw [NSException exceptionWithName:NSInternalInconsistencyException reason:@"Cannot change row height after the view has been presented" userInfo:nil];
     }
     _rowHeight = rowHeight;
-}
-
-- (void)setSearchBar:(UISearchBar *)searchBar
-{
-    if (self.hasAppeared) {
-        @throw [NSException exceptionWithName:NSInternalInconsistencyException reason:@"Cannot change override search bar after the view has been presented" userInfo:nil];
-    }
-    _searchBar = searchBar;
-}
-
-- (void)setSearchController:(UISearchDisplayController *)searchController
-{
-    if (self.hasAppeared) {
-        @throw [NSException exceptionWithName:NSInternalInconsistencyException reason:@"Cannot override search controller after the view has been presented" userInfo:nil];
-    }
-    _searchController = searchController;
 }
 
 #pragma mark - Set Up

--- a/Code/Controllers/ATLConversationListViewController.m
+++ b/Code/Controllers/ATLConversationListViewController.m
@@ -23,14 +23,12 @@
 
 static NSString *const ATLConversationCellReuseIdentifier = @"ATLConversationCellReuseIdentifier";
 
-@interface ATLConversationListViewController () <UIActionSheetDelegate, LYRQueryControllerDelegate, UISearchBarDelegate, UISearchControllerDelegate, UISearchDisplayDelegate>
+@interface ATLConversationListViewController () <UIActionSheetDelegate, LYRQueryControllerDelegate>
 
 @property (nonatomic) LYRQueryController *queryController;
 @property (nonatomic) LYRQueryController *searchQueryController;
 @property (nonatomic) LYRConversation *conversationToDelete;
 @property (nonatomic) LYRConversation *conversationSelectedBeforeContentChange;
-@property (nonatomic) UISearchDisplayController *searchController;
-@property (nonatomic) UISearchBar *searchBar;
 @property (nonatomic) BOOL hasAppeared;
 
 @end
@@ -197,6 +195,22 @@ NSString *const ATLConversationTableViewAccessibilityIdentifier = @"Conversation
         @throw [NSException exceptionWithName:NSInternalInconsistencyException reason:@"Cannot change row height after the view has been presented" userInfo:nil];
     }
     _rowHeight = rowHeight;
+}
+
+- (void)setSearchBar:(UISearchBar *)searchBar
+{
+    if (self.hasAppeared) {
+        @throw [NSException exceptionWithName:NSInternalInconsistencyException reason:@"Cannot change override search bar after the view has been presented" userInfo:nil];
+    }
+    _searchBar = searchBar;
+}
+
+- (void)setSearchController:(UISearchDisplayController *)searchController
+{
+    if (self.hasAppeared) {
+        @throw [NSException exceptionWithName:NSInternalInconsistencyException reason:@"Cannot override search controller after the view has been presented" userInfo:nil];
+    }
+    _searchController = searchController;
 }
 
 #pragma mark - Set Up

--- a/Code/Controllers/ATLConversationViewController.h
+++ b/Code/Controllers/ATLConversationViewController.h
@@ -149,7 +149,7 @@
  a Layer conversation and the ability to send messages. The controller's design and functionality closely correlates with
  the conversation view controller in Messages.
 */
-@interface ATLConversationViewController : ATLBaseConversationViewController <ATLAddressBarViewControllerDelegate>
+@interface ATLConversationViewController : ATLBaseConversationViewController <ATLAddressBarViewControllerDelegate, UIImagePickerControllerDelegate, UINavigationControllerDelegate>
 
 ///---------------------------------------
 /// @name Initializing a Controller
@@ -221,7 +221,7 @@
 @property (nonatomic) NSTimeInterval dateDisplayTimeInterval;
 
 /**
-@abstract A Boolean value that determines whether or not the controller marks all messages as read.
+ @abstract A Boolean value that determines whether or not the controller marks all messages as read.
  @discussion If `YES`, the controller will mark all messages in the conversation as read when it is presented.
  @default `YES`.
  */

--- a/Code/Controllers/ATLConversationViewController.m
+++ b/Code/Controllers/ATLConversationViewController.m
@@ -701,6 +701,10 @@ static NSString *const ATLPushNotificationSoundName = @"layerbell.caf";
     
     NSArray *changes = notification.userInfo[LYRClientObjectChangesUserInfoKey];
     for (NSDictionary *change in changes) {
+        
+        id changedObject = change[LYRObjectChangeObjectKey];
+        if (![changedObject isEqual:self.conversation]) continue;
+        
         LYRObjectChangeType changeType = [change[LYRObjectChangeTypeKey] integerValue];
         NSString *changedProperty = change[LYRObjectChangePropertyKey];
         if (changeType == LYRObjectChangeTypeUpdate && [changedProperty isEqualToString:@"participants"]) {

--- a/Code/Views/ATLMessageInputToolbar.h
+++ b/Code/Views/ATLMessageInputToolbar.h
@@ -101,6 +101,25 @@ extern NSString *const ATLMessageInputToolbarAccessibilityLabel;
 @property (nonatomic) UIButton *rightAccessoryButton;
 
 /**
+ @abstract The image displayed on left accessory button.
+ @default A `camera` icon.
+ */
+@property (nonatomic) UIImage *leftAccessoryImage;
+
+/**
+ @abstract The image displayed on right accessory button.
+ @default A `location` icon.
+ */
+@property (nonatomic) UIImage *rightAccessoryImage;
+
+/**
+ @abstract Determines whether or not the right accessory button displays an icon. 
+ @disucssion If NO, the right accessory button will display the text `SEND` at all times.
+ @default YES
+ */
+@property(nonatomic) BOOL displaysRightAccessoryImage;
+
+/**
  @abstract An automatically resizing message composition field.
  */
 @property (nonatomic) ATLMessageComposeTextView *textInputView;

--- a/Code/Views/ATLMessageInputToolbar.h
+++ b/Code/Views/ATLMessageInputToolbar.h
@@ -90,7 +90,7 @@ extern NSString *const ATLMessageInputToolbarAccessibilityLabel;
 
 /**
  @abstract The left accessory button for the view. 
- @discussion By default, the button displays a camera icon.
+ @discussion By default, the button displays a camera icon. If set to `nil` the `textInputView` will expand to the left edge of the toolbar.
  */
 @property (nonatomic) UIButton *leftAccessoryButton;
  

--- a/Code/Views/ATLMessageInputToolbar.m
+++ b/Code/Views/ATLMessageInputToolbar.m
@@ -63,7 +63,7 @@ static CGFloat const ATLButtonHeight = 28.0f;
         
         self.leftAccessoryImage = [UIImage imageNamed:@"AtlasResource.bundle/camera_dark"];
         self.rightAccessoryImage = [UIImage imageNamed:@"AtlasResource.bundle/location_dark"];
-        self.displaysRightAccessoryImage = NO;
+        self.displaysRightAccessoryImage = YES;
         self.firstAppearance = YES;
         
         self.leftAccessoryButton = [[UIButton alloc] init];
@@ -82,7 +82,6 @@ static CGFloat const ATLButtonHeight = 28.0f;
         [self addSubview:self.textInputView];
         
         self.rightAccessoryButton = [[UIButton alloc] init];
-        self.rightAccessoryButton.enabled = NO;
         [self.rightAccessoryButton addTarget:self action:@selector(rightAccessoryButtonTapped) forControlEvents:UIControlEventTouchUpInside];
         [self addSubview:self.rightAccessoryButton];
         [self configureRightAccessoryButtonState];
@@ -99,7 +98,7 @@ static CGFloat const ATLButtonHeight = 28.0f;
     [super layoutSubviews];
     
     if (self.firstAppearance) {
-        self.rightAccessoryButton.enabled = NO;
+        [self configureRightAccessoryButtonState];
         self.firstAppearance = NO;
     }
     
@@ -252,10 +251,8 @@ static CGFloat const ATLButtonHeight = 28.0f;
     }
     
     if (textView.text.length > 0 && [self.inputToolBarDelegate respondsToSelector:@selector(messageInputToolbarDidType:)]) {
-        self.rightAccessoryButton.enabled = YES;
         [self.inputToolBarDelegate messageInputToolbarDidType:self];
     } else if (textView.text.length == 0 && [self.inputToolBarDelegate respondsToSelector:@selector(messageInputToolbarDidEndTyping:)]) {
-        self.rightAccessoryButton.enabled = NO;
         [self.inputToolBarDelegate messageInputToolbarDidEndTyping:self];
     }
 
@@ -327,20 +324,38 @@ static CGFloat const ATLButtonHeight = 28.0f;
 
 - (void)configureRightAccessoryButtonState
 {
-    if (self.textInputView.text.length || !self.displaysRightAccessoryImage) {
-        self.rightAccessoryButton.accessibilityLabel = ATLMessageInputToolbarSendButton;
-        [self.rightAccessoryButton setImage:nil forState:UIControlStateNormal];
-        self.rightAccessoryButton.contentEdgeInsets = UIEdgeInsetsMake(2, 0, 0, 0);
-        self.rightAccessoryButton.titleLabel.font = [UIFont boldSystemFontOfSize:17];
-        [self.rightAccessoryButton setTitle:@"Send" forState:UIControlStateNormal];
-        [self.rightAccessoryButton setTitleColor:ATLBlueColor() forState:UIControlStateNormal];
-        [self.rightAccessoryButton setTitleColor:[UIColor grayColor] forState:UIControlStateDisabled];
+    if (self.textInputView.text.length) {
+        [self configureRightAccessoryButtonForText];
+        self.rightAccessoryButton.enabled = YES;
     } else {
-        self.rightAccessoryButton.accessibilityLabel = ATLMessageInputToolbarLocationButton;
-        [self.rightAccessoryButton setTitle:nil forState:UIControlStateNormal];
-        self.rightAccessoryButton.contentEdgeInsets = UIEdgeInsetsZero;
-        [self.rightAccessoryButton setImage:self.rightAccessoryImage forState:UIControlStateNormal];
+        if (self.displaysRightAccessoryImage) {
+            [self configureRightAccessoryButtonForImage];
+            self.rightAccessoryButton.enabled = YES;
+        } else {
+            [self configureRightAccessoryButtonForText];
+            self.rightAccessoryButton.enabled = NO;
+        }
     }
+}
+
+- (void)configureRightAccessoryButtonForText
+{
+    self.rightAccessoryButton.accessibilityLabel = ATLMessageInputToolbarSendButton;
+    [self.rightAccessoryButton setImage:nil forState:UIControlStateNormal];
+    self.rightAccessoryButton.contentEdgeInsets = UIEdgeInsetsMake(2, 0, 0, 0);
+    self.rightAccessoryButton.titleLabel.font = [UIFont boldSystemFontOfSize:17];
+    [self.rightAccessoryButton setTitle:@"Send" forState:UIControlStateNormal];
+    [self.rightAccessoryButton setTitleColor:ATLBlueColor() forState:UIControlStateNormal];
+    [self.rightAccessoryButton setTitleColor:[UIColor grayColor] forState:UIControlStateDisabled];
+}
+
+- (void)configureRightAccessoryButtonForImage
+{
+    self.rightAccessoryButton.enabled = YES;
+    self.rightAccessoryButton.accessibilityLabel = ATLMessageInputToolbarLocationButton;
+    self.rightAccessoryButton.contentEdgeInsets = UIEdgeInsetsZero;
+    [self.rightAccessoryButton setTitle:nil forState:UIControlStateNormal];
+    [self.rightAccessoryButton setImage:self.rightAccessoryImage forState:UIControlStateNormal];
 }
 
 

--- a/Examples/ATLSampleConversationListViewController.m
+++ b/Examples/ATLSampleConversationListViewController.m
@@ -60,6 +60,7 @@
 {
     ATLSampleConversationViewController *controller = [ATLSampleConversationViewController conversationViewControllerWithLayerClient:self.layerClient];
     controller.conversation = conversation;
+    controller.hidesBottomBarWhenPushed = YES;
     [self.navigationController pushViewController:controller animated:YES];
 }
 
@@ -76,6 +77,13 @@
 - (id<ATLAvatarItem>)conversationListViewController:(ATLConversationListViewController *)conversationListViewController avatarItemForConversation:(LYRConversation *)conversation
 {
     return [ATLSampleConversationAvatarItem new];
+}
+
+- (void)conversationListViewController:(ATLConversationListViewController *)conversationListViewController didSearchForText:(NSString *)searchText completion:(void (^)(NSSet *))completion
+{
+    NSSet *participants = [ATLUserMock allMockParticipants];
+    NSSet *filteredParticipants = [participants filteredSetUsingPredicate:[NSPredicate predicateWithFormat:@"SELF.fullName CONTAINS %@", searchText]];
+    completion(filteredParticipants);
 }
 
 #pragma mark - Conversation List View Controller Data Source Methods

--- a/Examples/ATLSampleConversationListViewController.m
+++ b/Examples/ATLSampleConversationListViewController.m
@@ -45,6 +45,7 @@
 {
     [super viewWillAppear:animated];
     [self.tableView reloadData];
+    self.searchBar = nil;
 }
 
 - (void)handleNewTap

--- a/Examples/ATLSampleConversationListViewController.m
+++ b/Examples/ATLSampleConversationListViewController.m
@@ -45,7 +45,6 @@
 {
     [super viewWillAppear:animated];
     [self.tableView reloadData];
-    self.searchBar = nil;
 }
 
 - (void)handleNewTap

--- a/Examples/ATLSampleConversationViewController.m
+++ b/Examples/ATLSampleConversationViewController.m
@@ -36,7 +36,7 @@
     [super viewDidLoad];
     self.dataSource = self;
     self.addressBarController.delegate = self;
-  
+    
     // Setup the dateformatter used by the dataSource.
     self.dateFormatter = [[NSDateFormatter alloc] init];
     self.dateFormatter.dateStyle = NSDateFormatterShortStyle;

--- a/Examples/Mocks/LYRMockContentStore.m
+++ b/Examples/Mocks/LYRMockContentStore.m
@@ -255,7 +255,7 @@
             return [NSPredicate predicateWithFormat:@"SELF.%@ <= %@", predicate.property, predicate.value];
 
         case LYRPredicateOperatorIsIn: {
-            NSPredicate *predicatee = [NSPredicate predicateWithFormat:@"%@ IN SELF.%@", predicate.value, predicate.property];
+            NSPredicate *predicatee = [NSPredicate predicateWithFormat:@"SELF.%@ CONTAINS %@ ", predicate.property,  predicate.value];
             return predicatee;
         }
         case LYRPredicateOperatorIsNotIn:

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -2,9 +2,9 @@ PODS:
   - Atlas (1.0.3):
     - LayerKit (>= 0.11.2)
   - Expecta (0.3.2)
-  - KIF (3.2.0):
-    - KIF/XCTest (= 3.2.0)
-  - KIF/XCTest (3.2.0)
+  - KIF (3.2.1):
+    - KIF/XCTest (= 3.2.1)
+  - KIF/XCTest (3.2.1)
   - KIFViewControllerActions (1.0.0):
     - KIF (>= 2.0.0)
   - LayerKit (0.11.2)
@@ -38,11 +38,11 @@ CHECKOUT OPTIONS:
 
 SPEC CHECKSUMS:
   Atlas: 2604bed303e97b19384bef7b276d37910b294b69
-  Expecta: ee641011fe10aa1855d487b40e4976dac50ec342
-  KIF: 6f94a23566fd05b809f5d3bc5231a965b51121b9
+  Expecta: 8c507baf13211207b1e9d0a741480600e6b4ed15
+  KIF: ef1691e54e1d969c3b4fd0b5b56a3d7ddf37f216
   KIFViewControllerActions: 73085acd975ebbfc954f7895ca1aaa9faa36b3c6
   LayerKit: 3546568785140970c3405d686a61af50260d6d48
   LYRCountDownLatch: 72a444f729ca5a8c6157c0b58f335a44e6702b48
-  OCMock: ecdd510b73ef397f2f97274785c1e87fd147c49f
+  OCMock: a10ea9f0a6e921651f96f78b6faee95ebc813b92
 
 COCOAPODS: 0.36.0

--- a/Tests/ATLConversationListViewControllerTest.m
+++ b/Tests/ATLConversationListViewControllerTest.m
@@ -257,22 +257,6 @@
     expect(^{ [self.viewController setAllowsEditing:YES]; }).to.raise(NSInternalInconsistencyException);
 }
 
-- (void)testToVerifySettingSearchControllerAfterViewLoadRaiseException
-{
-    self.viewController = [ATLSampleConversationListViewController conversationListViewControllerWithLayerClient:(LYRClient *)self.testInterface.layerClient];
-    [self setRootViewController:self.viewController];
-    [tester waitForTimeInterval:1.0]; // Allow controller to be presented.
-    expect(^{ [self.viewController setSearchController:nil]; }).to.raise(NSInternalInconsistencyException);
-}
-
-- (void)testToVerifySettingSearchBarAfterViewLoadRaiseException
-{
-    self.viewController = [ATLSampleConversationListViewController conversationListViewControllerWithLayerClient:(LYRClient *)self.testInterface.layerClient];
-    [self setRootViewController:self.viewController];
-    [tester waitForTimeInterval:1.0]; // Allow controller to be presented.
-    expect(^{ [self.viewController setSearchBar:nil]; }).to.raise(NSInternalInconsistencyException);
-}
-
 #pragma mark - ATLConversationListViewControllerDataSource
 
 - (void)testToVerifyConversationListViewControllerDataSource

--- a/Tests/ATLConversationListViewControllerTest.m
+++ b/Tests/ATLConversationListViewControllerTest.m
@@ -257,6 +257,22 @@
     expect(^{ [self.viewController setAllowsEditing:YES]; }).to.raise(NSInternalInconsistencyException);
 }
 
+- (void)testToVerifySettingSearchControllerAfterViewLoadRaiseException
+{
+    self.viewController = [ATLSampleConversationListViewController conversationListViewControllerWithLayerClient:(LYRClient *)self.testInterface.layerClient];
+    [self setRootViewController:self.viewController];
+    [tester waitForTimeInterval:1.0]; // Allow controller to be presented.
+    expect(^{ [self.viewController setSearchController:nil]; }).to.raise(NSInternalInconsistencyException);
+}
+
+- (void)testToVerifySettingSearchBarAfterViewLoadRaiseException
+{
+    self.viewController = [ATLSampleConversationListViewController conversationListViewControllerWithLayerClient:(LYRClient *)self.testInterface.layerClient];
+    [self setRootViewController:self.viewController];
+    [tester waitForTimeInterval:1.0]; // Allow controller to be presented.
+    expect(^{ [self.viewController setSearchBar:nil]; }).to.raise(NSInternalInconsistencyException);
+}
+
 #pragma mark - ATLConversationListViewControllerDataSource
 
 - (void)testToVerifyConversationListViewControllerDataSource

--- a/Tests/ATLConversationViewControllerTest.m
+++ b/Tests/ATLConversationViewControllerTest.m
@@ -96,27 +96,6 @@ extern NSString *const ATLMessageInputToolbarSendButton;
     [self sendPhotoMessage];
 }
 
-- (void)testToVerifyCorrectCellIsReturnedForMessage
-{
-    LYRMessagePartMock *messagePart1 = [LYRMessagePartMock messagePartWithText:@"How are you1?"];
-    LYRMessageMock *message1 = [self.testInterface.layerClient newMessageWithParts:@[messagePart1] options:nil error:nil];
-    [self.conversation sendMessage:message1 error:nil];
-    
-    LYRMessagePartMock *messagePart2 = [LYRMessagePartMock messagePartWithText:@"How are you2?"];
-    LYRMessageMock *message2 = [self.testInterface.layerClient newMessageWithParts:@[messagePart2] options:nil error:nil];
-    [self.conversation sendMessage:message2 error:nil];
-
-    LYRMessagePartMock *messagePart3 = [LYRMessagePartMock messagePartWithText:@"How are you3?"];
-    LYRMessageMock *message3 = [self.testInterface.layerClient newMessageWithParts:@[messagePart3] options:nil error:nil];
-    [self.conversation sendMessage:message3 error:nil];
-
-    [self setupConversationViewController];
-    [self setRootViewController:self.viewController];
-    id cell = [self.viewController collectionViewCellForMessage:(LYRMessage *)message3];
-    expect([cell class]).to.beSubclassOf([ATLMessageCollectionViewCell class]);
-    expect([cell accessibilityLabel]).to.equal(@"Message: How are you3?");
-}
-
 #pragma mark - ATLConversationViewControllerDelegate
 
 //- (void)conversationViewController:(ATLConversationViewController *)viewController didSendMessage:(LYRMessage *)message;
@@ -339,7 +318,7 @@ extern NSString *const ATLMessageInputToolbarSendButton;
     expect(error).to.beNil;
     [self.conversation sendMessage:message error:&error];
     expect(error).to.beNil;
-    [tester waitForViewWithAccessibilityLabel:[NSString stringWithFormat:@"Message: Photo"]];
+    [tester waitForViewWithAccessibilityLabel:[NSString stringWithFormat:@"Message: Image"]];
 }
 
 - (void)setRootViewController:(UIViewController *)controller

--- a/Tests/ATLMediaAttachmentTests.m
+++ b/Tests/ATLMediaAttachmentTests.m
@@ -154,6 +154,7 @@
 
 - (void)testMediaWithAsset
 {
+    [Expecta setAsynchronousTestTimeout:10];
     UIImage *image = ATLTestAttachmentMakeImageWithSize(CGSizeMake(1024, 512));
 
     // First, save the generated image to the album.

--- a/Tests/ATLMessageInputBarTest.m
+++ b/Tests/ATLMessageInputBarTest.m
@@ -34,6 +34,7 @@
 
 @property (nonatomic) ATLTestInterface *testInterface;
 @property (nonatomic) ATLSampleConversationViewController *viewController;
+@property (nonatomic) LYRConversation *conversation;
 
 @end
 
@@ -55,11 +56,7 @@ extern NSString *const ATLMessageInputToolbarSendButton;
     self.testInterface = [ATLTestInterface testIntefaceWithLayerClient:layerClient];
     
     ATLUserMock *mockUser1 = [ATLUserMock userWithMockUserName:ATLMockUserNameKlemen];
-    LYRConversationMock *conversation1 = [self.testInterface conversationWithParticipants:[NSSet setWithObject:mockUser1.participantIdentifier] lastMessageText:nil];
-    
-    self.viewController = [ATLSampleConversationViewController conversationViewControllerWithLayerClient:(LYRClient *)self.testInterface.layerClient];
-    self.viewController.conversation = (LYRConversation *)conversation1;
-    [self setRootViewController:self.viewController];
+    self.conversation = (LYRConversation *)[self.testInterface conversationWithParticipants:[NSSet setWithObject:mockUser1.participantIdentifier] lastMessageText:nil];
 }
 
 - (void)tearDown
@@ -72,6 +69,7 @@ extern NSString *const ATLMessageInputToolbarSendButton;
 
 - (void)testToVerifyMessageInputToolbarUI
 {
+    [self setRootViewController];
     [tester waitForViewWithAccessibilityLabel:ATLMessageInputToolbarCameraButton];
     [tester waitForViewWithAccessibilityLabel:ATLMessageInputToolbarTextInputView];
     [tester waitForViewWithAccessibilityLabel:ATLMessageInputToolbarLocationButton];
@@ -80,6 +78,7 @@ extern NSString *const ATLMessageInputToolbarSendButton;
 
 - (void)testToVerifyToVerifyTextChangesLocationButtonToSendButton
 {
+    [self setRootViewController];
     [tester waitForViewWithAccessibilityLabel:ATLMessageInputToolbarAccessibilityLabel];
     [tester waitForViewWithAccessibilityLabel:ATLMessageInputToolbarLocationButton];
     [tester enterText:@"A" intoViewWithAccessibilityLabel:ATLMessageInputToolbarTextInputView];
@@ -94,6 +93,7 @@ extern NSString *const ATLMessageInputToolbarSendButton;
 
 - (void)testToVerifyRightAccessoryButtonDelegateFunctionality
 {
+    [self setRootViewController];
     ATLMessageInputToolbar *toolBar = (ATLMessageInputToolbar *)[tester waitForViewWithAccessibilityLabel:ATLMessageInputToolbarAccessibilityLabel];
     id delegateMock = OCMProtocolMock(@protocol(ATLMessageInputToolbarDelegate));
     toolBar.inputToolBarDelegate = delegateMock;
@@ -110,6 +110,7 @@ extern NSString *const ATLMessageInputToolbarSendButton;
 
 - (void)testToVerifyLeftAccessoryButtonDelegateFunctionality
 {
+    [self setRootViewController];
     ATLMessageInputToolbar *toolBar = (ATLMessageInputToolbar *)[tester waitForViewWithAccessibilityLabel:ATLMessageInputToolbarAccessibilityLabel];
     id delegateMock = OCMProtocolMock(@protocol(ATLMessageInputToolbarDelegate));
     toolBar.inputToolBarDelegate = delegateMock;
@@ -126,6 +127,7 @@ extern NSString *const ATLMessageInputToolbarSendButton;
 
 - (void)testToVerifyMessageEnteredIsConsitentWithMessageToBeSent
 {
+    [self setRootViewController];
     ATLMessageInputToolbar *toolBar = (ATLMessageInputToolbar *)[tester waitForViewWithAccessibilityLabel:ATLMessageInputToolbarAccessibilityLabel];
     id delegateMock = OCMProtocolMock(@protocol(ATLMessageInputToolbarDelegate));
     toolBar.inputToolBarDelegate = delegateMock;
@@ -148,6 +150,7 @@ extern NSString *const ATLMessageInputToolbarSendButton;
 
 - (void)testToVerifyButtonEnablement
 {
+    [self setRootViewController];
     ATLMessageInputToolbar *toolBar = (ATLMessageInputToolbar *)[tester waitForViewWithAccessibilityLabel:ATLMessageInputToolbarAccessibilityLabel];
     expect(toolBar.rightAccessoryButton.highlighted).to.beTruthy;
     expect(toolBar.rightAccessoryButton.enabled).to.beTruthy;
@@ -158,6 +161,7 @@ extern NSString *const ATLMessageInputToolbarSendButton;
 
 - (void)testToVerifyTextEnterendDoesNotEnableButtons
 {
+    [self setRootViewController];
     self.viewController.conversation = nil;
     
     ATLMessageInputToolbar *toolBar = (ATLMessageInputToolbar *)[tester waitForViewWithAccessibilityLabel:ATLMessageInputToolbarAccessibilityLabel];
@@ -174,6 +178,7 @@ extern NSString *const ATLMessageInputToolbarSendButton;
 
 - (void)testToVerifySendingMessageWithPhoto
 {
+    [self setRootViewController];
     ATLMessageInputToolbar *toolBar = self.viewController.messageInputToolbar;
     id delegateMock = OCMProtocolMock(@protocol(ATLMessageInputToolbarDelegate));
     toolBar.inputToolBarDelegate = delegateMock;
@@ -201,6 +206,7 @@ extern NSString *const ATLMessageInputToolbarSendButton;
 
 - (void)testToVerifySending1LineOfTextWith2Photos
 {
+    [self setRootViewController];
     ATLMessageInputToolbar *toolBar = (ATLMessageInputToolbar *)[tester waitForViewWithAccessibilityLabel:@"Message Input Toolbar"];
     id delegateMock = OCMProtocolMock(@protocol(ATLMessageInputToolbarDelegate));
     toolBar.inputToolBarDelegate = delegateMock;
@@ -225,6 +231,7 @@ extern NSString *const ATLMessageInputToolbarSendButton;
 
 - (void)testToVerifySending5Photos
 {
+    [self setRootViewController];
     ATLMessageInputToolbar *toolBar = (ATLMessageInputToolbar *)[tester waitForViewWithAccessibilityLabel:@"Message Input Toolbar"];
     id delegateMock = OCMProtocolMock(@protocol(ATLMessageInputToolbarDelegate));
     toolBar.inputToolBarDelegate = delegateMock;
@@ -253,6 +260,7 @@ extern NSString *const ATLMessageInputToolbarSendButton;
 
 - (void)testToVerifyHeightOfInputBarIsCapped
 {
+    [self setRootViewController];
     ATLMessageInputToolbar *toolBar = (ATLMessageInputToolbar *)[tester waitForViewWithAccessibilityLabel:@"Message Input Toolbar"];
     CGFloat toolbarHeight = toolBar.frame.size.height;
     CGFloat toolbarNewHeight;
@@ -282,6 +290,7 @@ extern NSString *const ATLMessageInputToolbarSendButton;
 
 - (void)testToVerifySelectingAndRemovingAnImageKeepsFontConsistent
 {
+    [self setRootViewController];
     ATLMessageInputToolbar *toolBar = (ATLMessageInputToolbar *)[tester waitForViewWithAccessibilityLabel:@"Message Input Toolbar"];
     UIFont *font = toolBar.textInputView.font;
     
@@ -293,9 +302,47 @@ extern NSString *const ATLMessageInputToolbarSendButton;
     expect(font).to.equal(toolBar.textInputView.font);
 }
 
-- (void)setRootViewController:(UIViewController *)controller
+- (void)testToVerifyRightAcccessoryButtonEnablementWithImage
 {
-    [self.testInterface presentViewController:controller];
+    [self setRootViewController];
+    ATLMessageInputToolbar *toolBar = (ATLMessageInputToolbar *)[tester waitForViewWithAccessibilityLabel:@"Message Input Toolbar"];
+    UIImage *image = [UIImage imageNamed:@"test-logo"];
+    toolBar.rightAccessoryImage = image;
+    expect(toolBar.rightAccessoryButton.imageView.image).to.equal(image);
+    expect(toolBar.rightAccessoryButton.enabled).to.beTruthy();
+}
+
+- (void)testToVerifyRightAcccessoryButtonEnablementWithoutImage
+{
+    [self setRootViewController];
+    ATLMessageInputToolbar *toolBar = (ATLMessageInputToolbar *)[tester waitForViewWithAccessibilityLabel:@"Message Input Toolbar"];
+    toolBar.displaysRightAccessoryImage = NO;
+    
+    [tester enterText:@"test" intoViewWithAccessibilityLabel:ATLMessageInputToolbarTextInputView];
+    expect(toolBar.rightAccessoryButton.enabled).to.beTruthy();
+    
+    [tester clearTextFromViewWithAccessibilityLabel:ATLMessageInputToolbarTextInputView];
+    expect(toolBar.rightAccessoryButton.enabled).to.beFalsy();
+}
+
+- (void)testToVerifyCustomAccessoryButtonImages
+{
+    [self setRootViewController];
+    ATLMessageInputToolbar *toolBar = (ATLMessageInputToolbar *)[tester waitForViewWithAccessibilityLabel:@"Message Input Toolbar"];
+    UIImage *image = [UIImage imageNamed:@"test-logo"];
+    toolBar.rightAccessoryImage = image;
+    toolBar.leftAccessoryImage = image;
+    
+    expect(toolBar.rightAccessoryButton.imageView.image).to.equal(image);
+    expect(toolBar.leftAccessoryButton.imageView.image).to.equal(image);
+}
+
+- (void)setRootViewController
+{
+    self.viewController = [ATLSampleConversationViewController conversationViewControllerWithLayerClient:(LYRClient *)self.testInterface.layerClient];
+    self.viewController.conversation = self.conversation;
+    
+    [self.testInterface presentViewController:self.viewController];
     [tester waitForTimeInterval:1];
 }
 

--- a/Tests/LYRClientMockTests.m
+++ b/Tests/LYRClientMockTests.m
@@ -70,59 +70,6 @@
     expect(messages.count).to.equal(2);
 }
 
-- (void)testMessagesIndexInConversationPreserved
-{
-    ATLUserMock *mockUser = [ATLUserMock userWithMockUserName:ATLMockUserNameBlake];
-    LYRClientMock *client = [LYRClientMock layerClientMockWithAuthenticatedUserID:mockUser.participantIdentifier];
-    
-    NSSet *participants = [NSSet setWithObject:[[ATLUserMock randomUser] participantIdentifier]];
-    LYRConversationMock *conversation = [client newConversationWithParticipants:participants options:nil error:nil];
-    
-    LYRMessagePartMock *messagePart1 = [LYRMessagePartMock messagePartWithText:@"How are you?"];
-    LYRMessageMock *message1 = [client newMessageWithParts:@[messagePart1] options:nil error:nil];
-    [conversation sendMessage:message1 error:nil];
-    
-    LYRMessagePartMock *messagePart2 = [LYRMessagePartMock messagePartWithText:@"I am well"];
-    LYRMessageMock *message2 = [client newMessageWithParts:@[messagePart2] options:nil error:nil];
-    [conversation sendMessage:message2 error:nil];
-    
-    LYRQuery *query = [LYRQuery queryWithClass:[LYRMessage class]];
-    query.sortDescriptors = @[[NSSortDescriptor sortDescriptorWithKey:@"index" ascending:YES]];
-    query.predicate = [LYRPredicate predicateWithProperty:@"conversation" operator:LYRPredicateOperatorIsEqualTo value:conversation];
-    NSOrderedSet *messages = [client executeQuery:query error:nil];
-    expect(messages.count).to.equal(2);
-    expect([messages[0] index]).to.equal(0);
-    expect([messages[1] index]).to.equal(1);
-    expect(conversation.lastMessage).to.equal(message2);
-}
-
-- (void)testDeletingMessagesReindexesIndexOrder
-{
-    ATLUserMock *mockUser = [ATLUserMock userWithMockUserName:ATLMockUserNameBlake];
-    LYRClientMock *client = [LYRClientMock layerClientMockWithAuthenticatedUserID:mockUser.participantIdentifier];
-    
-    NSSet *participants = [NSSet setWithObject:[[ATLUserMock randomUser] participantIdentifier]];
-    LYRConversationMock *conversation = [client newConversationWithParticipants:participants options:nil error:nil];
-    
-    LYRMessagePartMock *messagePart1 = [LYRMessagePartMock messagePartWithText:@"How are you?"];
-    LYRMessageMock *message1 = [client newMessageWithParts:@[messagePart1] options:nil error:nil];
-    [conversation sendMessage:message1 error:nil];
-    
-    LYRMessagePartMock *messagePart2 = [LYRMessagePartMock messagePartWithText:@"I am well"];
-    LYRMessageMock *message2 = [client newMessageWithParts:@[messagePart2] options:nil error:nil];
-    [conversation sendMessage:message2 error:nil];
-    
-    [[LYRMockContentStore sharedStore] deleteMessage:message1];
-    
-    LYRQuery *query = [LYRQuery queryWithClass:[LYRMessage class]];
-    query.predicate = [LYRPredicate predicateWithProperty:@"conversation" operator:LYRPredicateOperatorIsEqualTo value:conversation];
-    NSOrderedSet *messages = [client executeQuery:query error:nil];
-    expect(messages.count).to.equal(1);
-    expect([messages[0] index]).to.equal(0);
-    expect(messages[0]).to.equal(message2);
-    expect(conversation.lastMessage).to.equal(message2);
-}
-
 - (void)testFetchingConversationByIdentifier
 {
     ATLUserMock *mockUser = [ATLUserMock userWithMockUserName:ATLMockUserNameBlake];


### PR DESCRIPTION
* Moved `searchController` property to public API on `ATLConversationListViewController`. 
* Moved `UIImagePickerControllerDelegate` and `UINavigationControllerDelegate` declarations to header of `ATLConversationViewController`.
* Added `leftAccessoryImage`, `rightAccessoryImage` and `displaysRightAccessoryImage` to `ATLMessageInputToolbar`. 