### PR TITLE
Nil the 'image' when setting the 'avatarItem' with just initials

### DIFF
--- a/Code/Views/ATLAvatarImageView.m
+++ b/Code/Views/ATLAvatarImageView.m
@@ -100,6 +100,7 @@ NSString *const ATLAvatarImageViewAccessibilityLabel = @"ATLAvatarImageViewAcces
     } else if (avatarItem.avatarImage) {
         self.image = avatarItem.avatarImage;
     } else if (avatarItem.avatarInitials) {
+        self.image = nil;
         self.initialsLabel.text = avatarItem.avatarInitials;
     }
     _avatarItem = avatarItem;


### PR DESCRIPTION
If a ```ATLParticipant``` doesn't have a ```avatarImageURL``` or an ```avatarImage```, whilst others do, then the avatar image view can behave erratically. The image will switch between nothing and something. Nil'ing the ```image``` when we have ```avatarInitials``` should fix the issue.