### PR TITLE
Update ATLAvatarImageView.m

### DIFF
--- a/Code/Views/ATLAvatarImageView.m
+++ b/Code/Views/ATLAvatarImageView.m
@@ -133,7 +133,7 @@ NSString *const ATLAvatarImageViewAccessibilityLabel = @"ATLAvatarImageViewAcces
          
 - (void)loadAvatarImageWithURL:(NSURL *)imageURL
 {
-    if (![imageURL isKindOfClass:[NSURL class]]) {
+    if (![imageURL isKindOfClass:[NSURL class]] || imageURL.absoluteString.length == 0) {
         NSLog(@"Cannot fetch image without URL");
         return;
     }


### PR DESCRIPTION
Without this, it used to crash in my project if the ```imageURL``` object was not nil, but empty