### PR TITLE
displaysAvatarItem out of sync with documentation

### DIFF
--- a/Code/Controllers/ATLConversationListViewController.h
+++ b/Code/Controllers/ATLConversationListViewController.h
@@ -174,7 +174,7 @@
  @abstract Informs the receiver if it should display an avatar item representing a conversation.
  @discussion When `YES`, an avatar item will be displayed for every conversation cell.
  Typically, this image will be an avatar image representing the user or group of users.
- @default `YES`
+ @default `NO`
  @raises NSInternalInconsistencyException Raised if the value is mutated after the receiver has been presented.
  */
 @property (nonatomic, assign) BOOL displaysAvatarItem;

--- a/Code/Controllers/ATLConversationListViewController.m
+++ b/Code/Controllers/ATLConversationListViewController.m
@@ -70,7 +70,7 @@ NSString *const ATLConversationTableViewAccessibilityIdentifier = @"Conversation
 {
     _cellClass = [ATLConversationTableViewCell class];
     _deletionModes = @[@(LYRDeletionModeLocal), @(LYRDeletionModeAllParticipants)];
-    _displaysAvatarItem = NO;
+    _displaysAvatarItem = YES;
     _allowsEditing = YES;
     _rowHeight = 76.0f;
 }

--- a/Code/Controllers/ATLConversationListViewController.m
+++ b/Code/Controllers/ATLConversationListViewController.m
@@ -70,7 +70,7 @@ NSString *const ATLConversationTableViewAccessibilityIdentifier = @"Conversation
 {
     _cellClass = [ATLConversationTableViewCell class];
     _deletionModes = @[@(LYRDeletionModeLocal), @(LYRDeletionModeAllParticipants)];
-    _displaysAvatarItem = YES;
+    _displaysAvatarItem = NO;
     _allowsEditing = YES;
     _rowHeight = 76.0f;
 }


### PR DESCRIPTION
Changed documentation of displaysAvatarItem to NO because initialization defaulted to NO. I assume that the documentation was supposed to change and not the code because this way will more clearly mirror iOS Messages app.