### PR TITLE
cornerRadius calculations for ATLAvatarImageView

### DIFF
--- a/Code/Views/ATLAvatarImageView.m
+++ b/Code/Views/ATLAvatarImageView.m
@@ -70,7 +70,7 @@ NSString *const ATLAvatarImageViewAccessibilityLabel = @"ATLAvatarImageViewAcces
     // Default UI Appearance
     _initialsFont = [UIFont systemFontOfSize:14];
     _initialsColor = [UIColor blackColor];
-    _avatarImageViewDiameter = 27;
+    _avatarImageViewDiameter = CGRectGetHeight(self.frame);
     
     self.clipsToBounds = YES;
     self.layer.cornerRadius = _avatarImageViewDiameter / 2;


### PR DESCRIPTION
ATLAvatarImageView wasn't working for custom components. The corner radius was set to a literal value. By keying off of the frame of the image view instead, we were able to get a more dynamic calucalation. Still room for improvement but this works and doesn't break anything going on in ATLConversationTableViewCell for example