### PR TITLE
Check fetched image prior to adding to cache

### DIFF
--- a/Code/Views/ATLAvatarImageView.m
+++ b/Code/Views/ATLAvatarImageView.m
@@ -149,7 +149,9 @@ NSString *const ATLAvatarImageViewAccessibilityLabel = @"ATLAvatarImageViewAcces
     // If not, fetch the image and add to the cache
     dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_BACKGROUND, 0), ^{
         UIImage *image = [UIImage imageWithData:[NSData dataWithContentsOfURL:imageURL]];
-        [[[self class] sharedImageCache] setObject:image forKey:stringURL cost:0];
+        if (image) {
+            [[[self class] sharedImageCache] setObject:image forKey:stringURL cost:0];
+        }
         dispatch_async(dispatch_get_main_queue(), ^{
             [UIView animateWithDuration:0.2 animations:^{
                 self.alpha = 0.0;


### PR DESCRIPTION
When I have a poor network connection I am seeing a lot of exceptions here, where image is nil.