### PR TITLE
conversation list storyboard support

### DIFF
--- a/Code/Controllers/ATLConversationListViewController.h
+++ b/Code/Controllers/ATLConversationListViewController.h
@@ -95,13 +95,12 @@
 /**
  @abstract Asks the data source for the table view cell reuse identifier for a conversation.
  @param conversationListViewController The `ATLConversationListViewController` requesting the string.
- @param conversation The `LYRConversation` object to display in the cell.
  @return A string that will be used to dequeue a cell from the table view.
  @discussion Applications that wish to use prototype cells from a UIStoryboard in the ATLConversationListViewController cannot register their cells programmatically.
  The cell must be given a reuse identifier in the UIStoryboard and that string needs to be passed into the ATLConversationListViewController so it can properly dequeue a
  reuseable cell. If 'nil' is returned, the table view will default to internal values for reuse identifiers.
  */
-- (NSString *)conversationListViewController:(ATLConversationListViewController *)conversationListViewController reuseIdentifierForConversation:(LYRConversation *)conversation;
+- (NSString *)reuseIdentifierForConversationListViewController:(ATLConversationListViewController *)conversationListViewController;
 
 /**
  @abstract Asks the data source for a string to display on the delete button for a given deletion mode.

--- a/Code/Controllers/ATLConversationListViewController.h
+++ b/Code/Controllers/ATLConversationListViewController.h
@@ -93,6 +93,17 @@
 - (id<ATLAvatarItem>)conversationListViewController:(ATLConversationListViewController *)conversationListViewController avatarItemForConversation:(LYRConversation *)conversation;
 
 /**
+ @abstract Asks the data source for the table view cell reuse identifier for a conversation.
+ @param conversationListViewController The `ATLConversationListViewController` requesting the string.
+ @param conversation The `LYRConversation` object to display in the cell.
+ @return A string that will be used to dequeue a cell from the table view.
+ @discussion Applications that wish to use prototype cells from a UIStoryboard in the ATLConversationListViewController cannot register their cells programmatically.
+ The cell must be given a reuse identifier in the UIStoryboard and that string needs to be passed into the ATLConversationListViewController so it can properly dequeue a
+ reuseable cell. If 'nil' is returned, the table view will default to internal values for reuse identifiers.
+ */
+- (NSString *)conversationListViewController:(ATLConversationListViewController *)conversationListViewController reuseIdentifierForConversation:(LYRConversation *)conversation;
+
+/**
  @abstract Asks the data source for a string to display on the delete button for a given deletion mode.
  @param conversationListViewController The `LYRConversationListViewController` in which the button title will appear.
  @param deletionMode The `LYRDeletionMode` for which a button has to be displayed.

--- a/Code/Controllers/ATLConversationListViewController.m
+++ b/Code/Controllers/ATLConversationListViewController.m
@@ -233,7 +233,9 @@ NSString *const ATLConversationTableViewAccessibilityIdentifier = @"Conversation
 
 - (UITableViewCell *)tableView:(UITableView *)tableView cellForRowAtIndexPath:(NSIndexPath *)indexPath
 {
-    UITableViewCell<ATLConversationPresenting> *conversationCell = [tableView dequeueReusableCellWithIdentifier:ATLConversationCellReuseIdentifier forIndexPath:indexPath];
+    NSString *reuseIdentifier = [self reuseIdentifierForConversation:nil atIndexPath:indexPath];
+    
+    UITableViewCell<ATLConversationPresenting> *conversationCell = [tableView dequeueReusableCellWithIdentifier:reuseIdentifier forIndexPath:indexPath];
     [self configureCell:conversationCell atIndexPath:indexPath];
     return conversationCell;
 }
@@ -352,6 +354,20 @@ NSString *const ATLConversationTableViewAccessibilityIdentifier = @"Conversation
         [self setEditing:NO animated:YES];
     }
     self.conversationToDelete = nil;
+}
+
+#pragma mark - Data Source
+
+- (NSString *)reuseIdentifierForConversation:(LYRConversation *)conversation atIndexPath:(NSIndexPath *)indexPath
+{
+    NSString *reuseIdentifier;
+    if ([self.dataSource respondsToSelector:@selector(conversationListViewController:reuseIdentifierForConversation:)]) {
+        reuseIdentifier = [self.dataSource conversationListViewController:self reuseIdentifierForConversation:conversation];
+    }
+    if (!reuseIdentifier) {
+        reuseIdentifier = ATLConversationCellReuseIdentifier;
+    }
+    return reuseIdentifier;
 }
 
 #pragma mark - LYRQueryControllerDelegate

--- a/Code/Controllers/ATLConversationListViewController.m
+++ b/Code/Controllers/ATLConversationListViewController.m
@@ -75,11 +75,6 @@ NSString *const ATLConversationTableViewAccessibilityIdentifier = @"Conversation
     _rowHeight = 76.0f;
 }
 
-- (void)loadView
-{
-    self.view = [[UITableView alloc] initWithFrame:CGRectZero style:UITableViewStylePlain];
-}
-
 - (id)init
 {
     [NSException raise:NSInternalInconsistencyException format:@"Failed to call designated initializer"];
@@ -101,9 +96,7 @@ NSString *const ATLConversationTableViewAccessibilityIdentifier = @"Conversation
     [super viewDidLoad];
     self.title = ATLConversationListViewControllerTitle;
     self.accessibilityLabel = ATLConversationListViewControllerTitle;
-    
-    self.tableView.delegate = self;
-    self.tableView.dataSource = self;
+
     self.tableView.accessibilityLabel = ATLConversationTableViewAccessibilityLabel;
     self.tableView.accessibilityIdentifier = ATLConversationTableViewAccessibilityIdentifier;
     self.tableView.tableFooterView = [[UIView alloc] initWithFrame:CGRectZero];

--- a/Code/Controllers/ATLConversationListViewController.m
+++ b/Code/Controllers/ATLConversationListViewController.m
@@ -354,8 +354,8 @@ NSString *const ATLConversationTableViewAccessibilityIdentifier = @"Conversation
 - (NSString *)reuseIdentifierForConversation:(LYRConversation *)conversation atIndexPath:(NSIndexPath *)indexPath
 {
     NSString *reuseIdentifier;
-    if ([self.dataSource respondsToSelector:@selector(conversationListViewController:reuseIdentifierForConversation:)]) {
-        reuseIdentifier = [self.dataSource conversationListViewController:self reuseIdentifierForConversation:conversation];
+    if ([self.dataSource respondsToSelector:@selector(reuseIdentifierForConversationListViewController:)]) {
+        reuseIdentifier = [self.dataSource reuseIdentifierForConversationListViewController:self];
     }
     if (!reuseIdentifier) {
         reuseIdentifier = ATLConversationCellReuseIdentifier;


### PR DESCRIPTION
The ATLConversationListViewController doesn't currently support the use of Storyboards. It forces the table cell reuse identifier on any subclasses which break the registration set up by the storyboard. This pull request exposes this API as well as removes some other superfluous code.