### PR TITLE
Fix for iOS 8 images from Photo Stream

### DIFF
--- a/Code/Models/ATLMediaAttachment.m
+++ b/Code/Models/ATLMediaAttachment.m
@@ -330,12 +330,31 @@ ALAsset *ATLMediaAttachmentFromAssetURL(NSURL *assetURL, ALAssetsLibrary *assetL
     dispatch_semaphore_t semaphore = dispatch_semaphore_create(0);
     __block ALAsset *resultAsset;
     dispatch_async(asyncQueue, ^{
+        
+        
         [assetLibrary assetForURL:assetURL resultBlock:^(ALAsset *asset) {
-            resultAsset = asset;
-            dispatch_semaphore_signal(semaphore);
-        } failureBlock:^(NSError *libraryError) {
-            dispatch_semaphore_signal(semaphore);
-        }];
+             if (asset){
+                 resultAsset = asset;
+                 dispatch_semaphore_signal(semaphore);
+             } else {
+                 // On iOS 8.1 [library assetForUrl] Photo Streams always returns nil. Try to obtain it in an alternative way
+                 
+                 [assetLibrary enumerateGroupsWithTypes:ALAssetsGroupPhotoStream usingBlock:^(ALAssetsGroup *group, BOOL *stop) {
+                      [group enumerateAssetsWithOptions:NSEnumerationReverse usingBlock:^(ALAsset *result, NSUInteger index, BOOL *stop) {
+                          if([result.defaultRepresentation.url isEqual:assetURL]) {
+                              resultAsset = result;
+                              *stop = YES;
+                              dispatch_semaphore_signal(semaphore);
+                              
+                          }
+                      }];
+                  } failureBlock:^(NSError *error) {
+                      dispatch_semaphore_signal(semaphore);
+                  }];
+             }
+         } failureBlock:^(NSError *error) {
+             dispatch_semaphore_signal(semaphore);
+         }];
     });
     dispatch_semaphore_wait(semaphore, DISPATCH_TIME_FOREVER);
     return resultAsset;


### PR DESCRIPTION
This is fix for selecting images from Photo Stream on iOS 8. Asset Libarary returns nil in assetForURL to obtain it we need search through all assets from PhotoStream and select it manually.