### PR TITLE
Fix incorrect if statement

### DIFF
--- a/Code/Views/ATLMessageCollectionViewCell.m
+++ b/Code/Views/ATLMessageCollectionViewCell.m
@@ -178,7 +178,7 @@ CGFloat const ATLMessageCellHorizontalMargin = 16.0f;
     
     // Fall-back to programatically requesting for a content download of
     // single message part messages (Android compatibillity).
-    if ([[self.message valueForKeyPath:@"parts.MIMEType"] isEqual:@[ATLMIMETypeImageJPEG]]) {
+    if ([[self.message valueForKeyPath:@"parts.MIMEType"] containsObject:ATLMIMETypeImageJPEG]) {
         if (fullResImagePart && (fullResImagePart.transferStatus == LYRContentTransferReadyForDownload)) {
             NSError *error;
             LYRProgress *progress = [fullResImagePart downloadContent:&error];


### PR DESCRIPTION
The if statement always returns “false” because [self.message valueForKeyPath:@"parts.MIMEType"] is an array.