### PR TITLE
Feature/layerkit 0.13.0

### DIFF
--- a/Atlas.podspec
+++ b/Atlas.podspec
@@ -18,5 +18,5 @@ Pod::Spec.new do |s|
   s.header_mappings_dir         = 'Code'
   s.ios.frameworks              = %w{UIKit CoreLocation MobileCoreServices}
   s.ios.deployment_target       = '7.0'
-  s.dependency                  'LayerKit', '>= 0.12.0'
+  s.dependency                  'LayerKit', '>= 0.13.0'
 end

--- a/Code/Controllers/ATLConversationViewController.m
+++ b/Code/Controllers/ATLConversationViewController.m
@@ -358,7 +358,7 @@ static NSString *const ATLPushNotificationSoundName = @"layerbell.caf";
     [cell shouldDisplayAvatarItem:self.shouldDisplayAvatarItem];
     
     if ([self shouldDisplayAvatarItemAtIndexPath:indexPath]) {
-        [cell updateWithSender:[self participantForIdentifier:message.sentByUserID]];
+        [cell updateWithSender:[self participantForIdentifier:message.sender.userID]];
     } else {
         [cell updateWithSender:nil];
     }
@@ -396,7 +396,7 @@ static NSString *const ATLPushNotificationSoundName = @"layerbell.caf";
 - (CGFloat)defaultCellHeightForItemAtIndexPath:(NSIndexPath *)indexPath
 {
     LYRMessage *message = [self.conversationDataSource messageAtCollectionViewIndexPath:indexPath];
-    if ([message.sentByUserID isEqualToString:self.layerClient.authenticatedUserID]) {
+    if ([message.sender.userID isEqualToString:self.layerClient.authenticatedUserID]) {
         return [ATLOutgoingMessageCollectionViewCell cellHeightForMessage:message inView:self.view];
     } else {
         return [ATLIncomingMessageCollectionViewCell cellHeightForMessage:message inView:self.view];
@@ -425,11 +425,11 @@ static NSString *const ATLPushNotificationSoundName = @"layerbell.caf";
     if (self.conversation.participants.count <= 2) return NO;
     
     LYRMessage *message = [self.conversationDataSource messageAtCollectionViewSection:section];
-    if ([message.sentByUserID isEqualToString:self.layerClient.authenticatedUserID]) return NO;
+    if ([message.sender.userID isEqualToString:self.layerClient.authenticatedUserID]) return NO;
 
     if (section > ATLNumberOfSectionsBeforeFirstMessageSection) {
         LYRMessage *previousMessage = [self.conversationDataSource messageAtCollectionViewSection:section - 1];
-        if ([previousMessage.sentByUserID isEqualToString:message.sentByUserID]) {
+        if ([previousMessage.sender.userID isEqualToString:message.sender.userID]) {
             return NO;
         }
     }
@@ -444,7 +444,7 @@ static NSString *const ATLPushNotificationSoundName = @"layerbell.caf";
     if (section != lastSection) return NO;
 
     LYRMessage *message = [self.conversationDataSource messageAtCollectionViewSection:section];
-    if (![message.sentByUserID isEqualToString:self.layerClient.authenticatedUserID]) return NO;
+    if (![message.sender.userID isEqualToString:self.layerClient.authenticatedUserID]) return NO;
     
     return YES;
 }
@@ -469,7 +469,7 @@ static NSString *const ATLPushNotificationSoundName = @"layerbell.caf";
     if (!self.shouldDisplayAvatarItem) return NO;
    
     LYRMessage *message = [self.conversationDataSource messageAtCollectionViewIndexPath:indexPath];
-    if ([message.sentByUserID isEqualToString:self.layerClient.authenticatedUserID]) {
+    if ([message.sender.userID isEqualToString:self.layerClient.authenticatedUserID]) {
         return NO;
     }
    
@@ -478,7 +478,7 @@ static NSString *const ATLPushNotificationSoundName = @"layerbell.caf";
     if (indexPath.section < lastSection) {
         LYRMessage *nextMessage = [self.conversationDataSource messageAtCollectionViewSection:indexPath.section + 1];
         // If the next message is sent by the same user, no
-        if ([nextMessage.sentByUserID isEqualToString:message.sentByUserID]) {
+        if ([nextMessage.sender.userID isEqualToString:message.sender.userID]) {
             return NO;
         }
     }
@@ -923,7 +923,7 @@ static NSString *const ATLPushNotificationSoundName = @"layerbell.caf";
         }
         
         LYRQuery *query = [LYRQuery queryWithQueryableClass:[LYRMessage class]];
-        LYRPredicate *senderPredicate = [LYRPredicate predicateWithProperty:@"sentByUserID" predicateOperator:LYRPredicateOperatorIsEqualTo value:participantIdentifier];
+        LYRPredicate *senderPredicate = [LYRPredicate predicateWithProperty:@"sender.userID" predicateOperator:LYRPredicateOperatorIsEqualTo value:participantIdentifier];
         LYRPredicate *objectIdentifiersPredicate = [LYRPredicate predicateWithProperty:@"identifier" predicateOperator:LYRPredicateOperatorIsIn value:messageIdentifiers];
         query.predicate = [LYRCompoundPredicate compoundPredicateWithType:LYRCompoundPredicateTypeAnd subpredicates:@[ senderPredicate, objectIdentifiersPredicate ]];
         query.resultType = LYRQueryResultTypeIdentifiers;
@@ -1034,7 +1034,7 @@ static NSString *const ATLPushNotificationSoundName = @"layerbell.caf";
         reuseIdentifier = [self.dataSource conversationViewController:self reuseIdentifierForMessage:message];
     }
     if (!reuseIdentifier) {
-        if ([self.layerClient.authenticatedUserID isEqualToString:message.sentByUserID]) {
+        if ([self.layerClient.authenticatedUserID isEqualToString:message.sender.userID]) {
             reuseIdentifier = ATLOutgoingMessageCellIdentifier;
         } else {
             reuseIdentifier = ATLIncomingMessageCellIdentifier;
@@ -1182,7 +1182,7 @@ static NSString *const ATLPushNotificationSoundName = @"layerbell.caf";
 
 - (NSString *)participantNameForMessage:(LYRMessage *)message
 {
-    id<ATLParticipant> participant = [self participantForIdentifier:message.sentByUserID];
+    id<ATLParticipant> participant = [self participantForIdentifier:message.sender.userID];
     NSString *participantName = participant.fullName ?: @"Unknown User";
     return participantName;
 }

--- a/Examples/ATLSampleConversationListViewController.m
+++ b/Examples/ATLSampleConversationListViewController.m
@@ -102,9 +102,9 @@
     
     // Put the latest message sender's name first
     ATLUserMock *firstUser;
-    if (![conversation.lastMessage.sentByUserID isEqualToString:self.layerClient.authenticatedUserID]) {
+    if (![conversation.lastMessage.sender.userID isEqualToString:self.layerClient.authenticatedUserID]) {
         if (conversation.lastMessage) {
-            NSPredicate *searchPredicate = [NSPredicate predicateWithFormat:@"SELF.participantIdentifier IN %@", conversation.lastMessage.sentByUserID];
+            NSPredicate *searchPredicate = [NSPredicate predicateWithFormat:@"SELF.participantIdentifier IN %@", conversation.lastMessage.sender.userID];
             ATLUserMock *lastMessageSender = [[[participants filteredSetUsingPredicate:searchPredicate] allObjects] lastObject];
             if (lastMessageSender) {
                 firstUser = lastMessageSender;

--- a/Examples/Mocks/LYRMessageMock.h
+++ b/Examples/Mocks/LYRMessageMock.h
@@ -39,7 +39,6 @@
 @property (nonatomic, readonly) BOOL isUnread LYR_QUERYABLE_PROPERTY;
 @property (nonatomic) NSDate *sentAt LYR_QUERYABLE_PROPERTY;
 @property (nonatomic) NSDate *receivedAt LYR_QUERYABLE_PROPERTY;
-//@property (nonatomic, readonly) NSString *sentByUserID LYR_QUERYABLE_PROPERTY;
 @property (nonatomic, readonly) LYRActorMock *sender;
 @property (nonatomic) NSDictionary *recipientStatusByUserID;
 

--- a/Examples/Mocks/LYRMessageMock.h
+++ b/Examples/Mocks/LYRMessageMock.h
@@ -22,6 +22,12 @@
 
 @class LYRConversationMock;
 
+@interface LYRActorMock : NSObject
+
+@property (nonatomic, readwrite) NSString *userID;
+@property (nonatomic, readwrite) NSString *name;
+
+@end
 @interface LYRMessageMock : NSObject <LYRQueryable>
 
 @property (nonatomic, readonly) NSURL *identifier LYR_QUERYABLE_PROPERTY;
@@ -33,7 +39,8 @@
 @property (nonatomic, readonly) BOOL isUnread LYR_QUERYABLE_PROPERTY;
 @property (nonatomic) NSDate *sentAt LYR_QUERYABLE_PROPERTY;
 @property (nonatomic) NSDate *receivedAt LYR_QUERYABLE_PROPERTY;
-@property (nonatomic, readonly) NSString *sentByUserID LYR_QUERYABLE_PROPERTY;
+//@property (nonatomic, readonly) NSString *sentByUserID LYR_QUERYABLE_PROPERTY;
+@property (nonatomic, readonly) LYRActorMock *sender;
 @property (nonatomic) NSDictionary *recipientStatusByUserID;
 
 + (instancetype)newMessageWithParts:(NSArray *)messageParts senderID:(NSString *)senderID;

--- a/Examples/Mocks/LYRMessageMock.m
+++ b/Examples/Mocks/LYRMessageMock.m
@@ -20,13 +20,16 @@
 #import "LYRMessageMock.h"
 #import "LYRMockContentStore.h"
 
+@implementation LYRActorMock
+@end
+
 @interface LYRMessageMock ()
 
 @property (nonatomic, readwrite) NSURL *identifier;
 @property (nonatomic, readwrite) BOOL isSent;
 @property (nonatomic, readwrite) BOOL isDeleted;
 @property (nonatomic, readwrite) BOOL isUnread;
-@property (nonatomic, readwrite) NSString *sentByUserID;
+@property (nonatomic, readwrite) LYRActorMock *sender;
 
 @end
 
@@ -37,7 +40,8 @@
     self = [super init];
     if (self) {
         _parts = messageParts;
-        _sentByUserID = senderID;
+        _sender = [LYRActorMock new];
+        _sender.userID = senderID;
     }
     return self;    
 }

--- a/Podfile
+++ b/Podfile
@@ -1,16 +1,18 @@
 platform :ios, '7.0'
 
+source 'git@github.com:layerhq/cocoapods-specs.git'
+
 # Import CocoaPods sources
 source 'https://github.com/CocoaPods/Specs.git'
 
 target 'Programmatic' do
   pod 'Atlas', path: '.'
-  pod 'LayerKit'
+  pod 'LayerKit', git: 'git@github.com:layerhq/LayerKit.git', branch: 'feature/APPS-1025-conversation-uniquing'
 end
 
 target 'Storyboard' do
   pod 'Atlas', path: '.'
-  pod 'LayerKit'
+  pod 'LayerKit', git: 'git@github.com:layerhq/LayerKit.git', branch: 'feature/APPS-1025-conversation-uniquing'
 end
 
 target 'ProgrammaticTests' do

--- a/Podfile
+++ b/Podfile
@@ -7,12 +7,12 @@ source 'https://github.com/CocoaPods/Specs.git'
 
 target 'Programmatic' do
   pod 'Atlas', path: '.'
-  pod 'LayerKit', git: 'git@github.com:layerhq/LayerKit.git', branch: 'feature/APPS-1025-conversation-uniquing'
+  pod 'LayerKit'
 end
 
 target 'Storyboard' do
   pod 'Atlas', path: '.'
-  pod 'LayerKit', git: 'git@github.com:layerhq/LayerKit.git', branch: 'feature/APPS-1025-conversation-uniquing'
+  pod 'LayerKit'
 end
 
 target 'ProgrammaticTests' do

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,22 +1,86 @@
 PODS:
   - Atlas (1.0.5):
     - LayerKit (>= 0.12.0)
+  - CocoaLumberjack (1.8.1):
+    - CocoaLumberjack/Extensions (= 1.8.1)
+  - CocoaLumberjack/Core (1.8.1)
+  - CocoaLumberjack/Extensions (1.8.1):
+    - CocoaLumberjack/Core
+  - CocoaSPDY-Layer (20150216155524251)
   - Expecta (0.4.2)
+  - FMDB/common (2.4-20141216161347845)
+  - FMDB/standalone/FTS (2.4-20141216161347845):
+    - FMDB/common
+    - sqlite3/unicode61
+  - FMDBMigrationManager (1.3.4):
+    - FMDB/common (~> 2.3)
+  - GCNetworkReachability (1.3.2)
   - KIF (3.2.1):
     - KIF/XCTest (= 3.2.1)
   - KIF/XCTest (3.2.1)
   - KIFViewControllerActions (1.0.0):
     - KIF (>= 2.0.0)
-  - LayerKit (0.12.0)
+  - layer-client-messaging-schema (20150330135300206.11)
+  - layer-thrift (0.73.0):
+    - layer-thrift/Defaults (= 0.73.0)
+    - thrift (~> 0.9.1)
+  - layer-thrift/ctrl (0.73.0):
+    - thrift (~> 0.9.1)
+  - layer-thrift/Defaults (0.73.0):
+    - layer-thrift/ctrl
+    - layer-thrift/messaging
+    - layer-thrift/policy
+    - layer-thrift/shift
+    - thrift (~> 0.9.1)
+  - layer-thrift/messaging (0.73.0):
+    - thrift (~> 0.9.1)
+  - layer-thrift/policy (0.73.0):
+    - thrift (~> 0.9.1)
+  - layer-thrift/shift (0.73.0):
+    - thrift (~> 0.9.1)
+  - LayerKit (0.13.0-rc1):
+    - CocoaLumberjack (~> 1.8.1)
+    - CocoaSPDY-Layer (~> 20150216155524251)
+    - FMDB/standalone/FTS (= 2.4-20141216161347845)
+    - FMDBMigrationManager (~> 1.3.0)
+    - GCNetworkReachability (~> 1.3.2)
+    - layer-client-messaging-schema (= 20150330135300206.11)
+    - layer-thrift (= 0.73.0)
+    - LayerKit/Public (= 0.13.0-rc1)
+    - sqlite3 (= 3.8.7.4-1)
+    - TransitionKit (~> 2.1.0)
+    - ZipArchive (~> 1.4)
+  - LayerKit/Public (0.13.0-rc1):
+    - CocoaLumberjack (~> 1.8.1)
+    - CocoaSPDY-Layer (~> 20150216155524251)
+    - FMDB/standalone/FTS (= 2.4-20141216161347845)
+    - FMDBMigrationManager (~> 1.3.0)
+    - GCNetworkReachability (~> 1.3.2)
+    - layer-client-messaging-schema (= 20150330135300206.11)
+    - layer-thrift (= 0.73.0)
+    - sqlite3 (= 3.8.7.4-1)
+    - TransitionKit (~> 2.1.0)
+    - ZipArchive (~> 1.4)
   - LYRCountDownLatch (0.9.0)
   - OCMock (3.1.2)
+  - sqlite3 (3.8.7.4-1):
+    - sqlite3/common (= 3.8.7.4-1)
+  - sqlite3/common (3.8.7.4-1)
+  - sqlite3/fts (3.8.7.4-1):
+    - sqlite3/common
+  - sqlite3/unicode61 (3.8.7.4-1):
+    - sqlite3/common
+    - sqlite3/fts
+  - thrift (0.9.2)
+  - TransitionKit (2.1.1)
+  - ZipArchive (1.4.0)
 
 DEPENDENCIES:
   - Atlas (from `.`)
   - Expecta
   - KIF
   - KIFViewControllerActions (from `https://github.com/blakewatters/KIFViewControllerActions.git`)
-  - LayerKit
+  - LayerKit (from `git@github.com:layerhq/LayerKit.git`, branch `feature/APPS-1025-conversation-uniquing`)
   - LYRCountDownLatch (from `https://github.com/layerhq/LYRCountDownLatch.git`)
   - OCMock
 
@@ -25,6 +89,9 @@ EXTERNAL SOURCES:
     :path: "."
   KIFViewControllerActions:
     :git: https://github.com/blakewatters/KIFViewControllerActions.git
+  LayerKit:
+    :branch: feature/APPS-1025-conversation-uniquing
+    :git: git@github.com:layerhq/LayerKit.git
   LYRCountDownLatch:
     :git: https://github.com/layerhq/LYRCountDownLatch.git
 
@@ -32,17 +99,31 @@ CHECKOUT OPTIONS:
   KIFViewControllerActions:
     :commit: fbcaaaf2a6236c6ed840ce011a44f7e3e1f7570d
     :git: https://github.com/blakewatters/KIFViewControllerActions.git
+  LayerKit:
+    :commit: 88372bb7f0859189135dbe9dbf5749158948c2b7
+    :git: git@github.com:layerhq/LayerKit.git
   LYRCountDownLatch:
     :commit: 02119f855ad14e7fc0dae32bbbf17c735a281cfe
     :git: https://github.com/layerhq/LYRCountDownLatch.git
 
 SPEC CHECKSUMS:
   Atlas: bec1cdd8b02ea9cf28ab9f6ea93d5cb694c4e994
+  CocoaLumberjack: 555162681b9c20a271909b235c43f6bbd5d512e1
+  CocoaSPDY-Layer: 7a4b08281caa2757040582c19f54884bc2becdf4
   Expecta: 78b4e8b0c8291fa4524d7f74016b6065c2e391ec
+  FMDB: 6f76580f1e129ea33a47220c9f7d91be65885563
+  FMDBMigrationManager: aa46d473c863b6ade5676c49b73f56540b358ad7
+  GCNetworkReachability: 2a7dd53d362220326b3e38df68c91b3ef84418d1
   KIF: ef1691e54e1d969c3b4fd0b5b56a3d7ddf37f216
   KIFViewControllerActions: 73085acd975ebbfc954f7895ca1aaa9faa36b3c6
-  LayerKit: 980c640d69241b574a2a0847788dd992acb0cd89
+  layer-client-messaging-schema: a5696f898a84d8bdae313d52d1c2fdf2e5a7c231
+  layer-thrift: 99d975106c0fef7ab04284e7d098dea1422cc01f
+  LayerKit: 7b24abb989246fdcae2339b2469550627e8d5038
   LYRCountDownLatch: 72a444f729ca5a8c6157c0b58f335a44e6702b48
   OCMock: a10ea9f0a6e921651f96f78b6faee95ebc813b92
+  sqlite3: d1be4925916ff3fa11256acbc772a6b10d490880
+  thrift: 54db2dc6b2918a6d38a866232e329e925471ddd6
+  TransitionKit: 3a14b6acc7cf2d1dd3e454e24dbad1cfab9a1ef1
+  ZipArchive: e25a4373192673e3229ac8d6e9f64a3e5713c966
 
 COCOAPODS: 0.36.4

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,86 +1,22 @@
 PODS:
   - Atlas (1.0.5):
-    - LayerKit (>= 0.12.0)
-  - CocoaLumberjack (1.8.1):
-    - CocoaLumberjack/Extensions (= 1.8.1)
-  - CocoaLumberjack/Core (1.8.1)
-  - CocoaLumberjack/Extensions (1.8.1):
-    - CocoaLumberjack/Core
-  - CocoaSPDY-Layer (20150216155524251)
+    - LayerKit (>= 0.13.0)
   - Expecta (0.4.2)
-  - FMDB/common (2.4-20141216161347845)
-  - FMDB/standalone/FTS (2.4-20141216161347845):
-    - FMDB/common
-    - sqlite3/unicode61
-  - FMDBMigrationManager (1.3.4):
-    - FMDB/common (~> 2.3)
-  - GCNetworkReachability (1.3.2)
   - KIF (3.2.1):
     - KIF/XCTest (= 3.2.1)
   - KIF/XCTest (3.2.1)
   - KIFViewControllerActions (1.0.0):
     - KIF (>= 2.0.0)
-  - layer-client-messaging-schema (20150330135300206.11)
-  - layer-thrift (0.73.0):
-    - layer-thrift/Defaults (= 0.73.0)
-    - thrift (~> 0.9.1)
-  - layer-thrift/ctrl (0.73.0):
-    - thrift (~> 0.9.1)
-  - layer-thrift/Defaults (0.73.0):
-    - layer-thrift/ctrl
-    - layer-thrift/messaging
-    - layer-thrift/policy
-    - layer-thrift/shift
-    - thrift (~> 0.9.1)
-  - layer-thrift/messaging (0.73.0):
-    - thrift (~> 0.9.1)
-  - layer-thrift/policy (0.73.0):
-    - thrift (~> 0.9.1)
-  - layer-thrift/shift (0.73.0):
-    - thrift (~> 0.9.1)
-  - LayerKit (0.13.0-rc1):
-    - CocoaLumberjack (~> 1.8.1)
-    - CocoaSPDY-Layer (~> 20150216155524251)
-    - FMDB/standalone/FTS (= 2.4-20141216161347845)
-    - FMDBMigrationManager (~> 1.3.0)
-    - GCNetworkReachability (~> 1.3.2)
-    - layer-client-messaging-schema (= 20150330135300206.11)
-    - layer-thrift (= 0.73.0)
-    - LayerKit/Public (= 0.13.0-rc1)
-    - sqlite3 (= 3.8.7.4-1)
-    - TransitionKit (~> 2.1.0)
-    - ZipArchive (~> 1.4)
-  - LayerKit/Public (0.13.0-rc1):
-    - CocoaLumberjack (~> 1.8.1)
-    - CocoaSPDY-Layer (~> 20150216155524251)
-    - FMDB/standalone/FTS (= 2.4-20141216161347845)
-    - FMDBMigrationManager (~> 1.3.0)
-    - GCNetworkReachability (~> 1.3.2)
-    - layer-client-messaging-schema (= 20150330135300206.11)
-    - layer-thrift (= 0.73.0)
-    - sqlite3 (= 3.8.7.4-1)
-    - TransitionKit (~> 2.1.0)
-    - ZipArchive (~> 1.4)
+  - LayerKit (0.13.0)
   - LYRCountDownLatch (0.9.0)
   - OCMock (3.1.2)
-  - sqlite3 (3.8.7.4-1):
-    - sqlite3/common (= 3.8.7.4-1)
-  - sqlite3/common (3.8.7.4-1)
-  - sqlite3/fts (3.8.7.4-1):
-    - sqlite3/common
-  - sqlite3/unicode61 (3.8.7.4-1):
-    - sqlite3/common
-    - sqlite3/fts
-  - thrift (0.9.2)
-  - TransitionKit (2.1.1)
-  - ZipArchive (1.4.0)
 
 DEPENDENCIES:
   - Atlas (from `.`)
   - Expecta
   - KIF
   - KIFViewControllerActions (from `https://github.com/blakewatters/KIFViewControllerActions.git`)
-  - LayerKit (from `git@github.com:layerhq/LayerKit.git`, branch `feature/APPS-1025-conversation-uniquing`)
+  - LayerKit
   - LYRCountDownLatch (from `https://github.com/layerhq/LYRCountDownLatch.git`)
   - OCMock
 
@@ -89,9 +25,6 @@ EXTERNAL SOURCES:
     :path: "."
   KIFViewControllerActions:
     :git: https://github.com/blakewatters/KIFViewControllerActions.git
-  LayerKit:
-    :branch: feature/APPS-1025-conversation-uniquing
-    :git: git@github.com:layerhq/LayerKit.git
   LYRCountDownLatch:
     :git: https://github.com/layerhq/LYRCountDownLatch.git
 
@@ -99,31 +32,17 @@ CHECKOUT OPTIONS:
   KIFViewControllerActions:
     :commit: fbcaaaf2a6236c6ed840ce011a44f7e3e1f7570d
     :git: https://github.com/blakewatters/KIFViewControllerActions.git
-  LayerKit:
-    :commit: 88372bb7f0859189135dbe9dbf5749158948c2b7
-    :git: git@github.com:layerhq/LayerKit.git
   LYRCountDownLatch:
     :commit: 02119f855ad14e7fc0dae32bbbf17c735a281cfe
     :git: https://github.com/layerhq/LYRCountDownLatch.git
 
 SPEC CHECKSUMS:
-  Atlas: bec1cdd8b02ea9cf28ab9f6ea93d5cb694c4e994
-  CocoaLumberjack: 555162681b9c20a271909b235c43f6bbd5d512e1
-  CocoaSPDY-Layer: 7a4b08281caa2757040582c19f54884bc2becdf4
+  Atlas: d5ec3843f90f029f60d883e7a0c9121261b3d4be
   Expecta: 78b4e8b0c8291fa4524d7f74016b6065c2e391ec
-  FMDB: 6f76580f1e129ea33a47220c9f7d91be65885563
-  FMDBMigrationManager: aa46d473c863b6ade5676c49b73f56540b358ad7
-  GCNetworkReachability: 2a7dd53d362220326b3e38df68c91b3ef84418d1
   KIF: ef1691e54e1d969c3b4fd0b5b56a3d7ddf37f216
   KIFViewControllerActions: 73085acd975ebbfc954f7895ca1aaa9faa36b3c6
-  layer-client-messaging-schema: a5696f898a84d8bdae313d52d1c2fdf2e5a7c231
-  layer-thrift: 99d975106c0fef7ab04284e7d098dea1422cc01f
-  LayerKit: 7b24abb989246fdcae2339b2469550627e8d5038
+  LayerKit: e8c4abff3198af5f3eab183aaf324e199a302a4e
   LYRCountDownLatch: 72a444f729ca5a8c6157c0b58f335a44e6702b48
   OCMock: a10ea9f0a6e921651f96f78b6faee95ebc813b92
-  sqlite3: d1be4925916ff3fa11256acbc772a6b10d490880
-  thrift: 54db2dc6b2918a6d38a866232e329e925471ddd6
-  TransitionKit: 3a14b6acc7cf2d1dd3e454e24dbad1cfab9a1ef1
-  ZipArchive: e25a4373192673e3229ac8d6e9f64a3e5713c966
 
-COCOAPODS: 0.36.4
+COCOAPODS: 0.37.0

--- a/Tests/ATLConversationListViewControllerTest.m
+++ b/Tests/ATLConversationListViewControllerTest.m
@@ -150,7 +150,7 @@ extern NSString *const ATLAvatarImageViewAccessibilityLabel;
     [tester tapViewWithAccessibilityLabel:[NSString stringWithFormat:@"Delete %@", mockUser3.fullName]];
     [self deleteConversation:conversation3 deletionMode:LYRDeletionModeLocal];
     
-    LYRQuery *query = [LYRQuery queryWithClass:[LYRConversation class]];
+    LYRQuery *query = [LYRQuery queryWithQueryableClass:[LYRConversation class]];
     NSError *error;
     NSOrderedSet *conversations = [self.testInterface.layerClient executeQuery:query error:&error];
     expect(error).to.beNil;

--- a/Tests/ATLTestInterface.m
+++ b/Tests/ATLTestInterface.m
@@ -104,9 +104,9 @@ LYRMessagePartMock *ATLMessagePartWithLocation(CLLocation *location)
     
     // Put the latest message sender's name first
     ATLUserMock *firstUser;
-    if (![conversation.lastMessage.sentByUserID isEqualToString:self.layerClient.authenticatedUserID]) {
+    if (![conversation.lastMessage.sender.userID isEqualToString:self.layerClient.authenticatedUserID]) {
         if (conversation.lastMessage) {
-            NSPredicate *searchPredicate = [NSPredicate predicateWithFormat:@"SELF.participantIdentifier IN %@", conversation.lastMessage.sentByUserID];
+            NSPredicate *searchPredicate = [NSPredicate predicateWithFormat:@"SELF.participantIdentifier IN %@", conversation.lastMessage.sender.userID];
             ATLUserMock *lastMessageSender = [[[participants filteredSetUsingPredicate:searchPredicate] allObjects] lastObject];
             if (lastMessageSender) {
                 firstUser = lastMessageSender;

--- a/Tests/LYRClientMockTests.m
+++ b/Tests/LYRClientMockTests.m
@@ -64,8 +64,8 @@
     LYRMessageMock *message2 = [client newMessageWithParts:@[messagePart2] options:nil error:nil];
     [conversation sendMessage:message2 error:nil];
     
-    LYRQuery *query = [LYRQuery queryWithClass:[LYRMessage class]];
-    query.predicate = [LYRPredicate predicateWithProperty:@"conversation" operator:LYRPredicateOperatorIsEqualTo value:conversation];
+    LYRQuery *query = [LYRQuery queryWithQueryableClass:[LYRMessage class]];
+    query.predicate = [LYRPredicate predicateWithProperty:@"conversation" predicateOperator:LYRPredicateOperatorIsEqualTo value:conversation];
     NSOrderedSet *messages = [client executeQuery:query error:nil];
     expect(messages.count).to.equal(2);
 }
@@ -88,12 +88,12 @@
     LYRMessageMock *message2 = [client newMessageWithParts:@[messagePart2] options:nil error:nil];
     [conversation2 sendMessage:message2 error:nil];
 
-    LYRQuery *query = [LYRQuery queryWithClass:[LYRConversation class]];
-    query.predicate = [LYRPredicate predicateWithProperty:@"identifier" operator:LYRPredicateOperatorIsEqualTo value:conversation1.identifier];
+    LYRQuery *query = [LYRQuery queryWithQueryableClass:[LYRConversation class]];
+    query.predicate = [LYRPredicate predicateWithProperty:@"identifier" predicateOperator:LYRPredicateOperatorIsEqualTo value:conversation1.identifier];
     LYRConversationMock *fetchedConversation = [[client executeQuery:query error:nil] lastObject];
     expect(conversation1).to.equal(fetchedConversation);
     
-    query.predicate = [LYRPredicate predicateWithProperty:@"identifier" operator:LYRPredicateOperatorIsEqualTo value:conversation2.identifier];
+    query.predicate = [LYRPredicate predicateWithProperty:@"identifier" predicateOperator:LYRPredicateOperatorIsEqualTo value:conversation2.identifier];
     fetchedConversation = [[client executeQuery:query error:nil] lastObject];
     expect(conversation2).to.equal(fetchedConversation);
 }


### PR DESCRIPTION
This PR updates Atlas with the changes made in `LayerKit` v 0.13.0 that introduces the `LYRActor` object.  This object replaces the `LYRMessage` property `sentByUserID`.  `LYRActor` has properties `userID` and `name`, which allows for system messages in conversations.