### PR TITLE
Feature/public avatar property

### DIFF
--- a/Code/Controllers/ATLConversationViewController.h
+++ b/Code/Controllers/ATLConversationViewController.h
@@ -227,4 +227,10 @@
  */
 @property (nonatomic) BOOL marksMessagesAsRead;
 
+/**
+ @abstract A Boolean value that determines whether or not an avatar is shown if there is only one other participant in the conversation.
+ @default `NO`.
+ */
+@property (nonatomic) BOOL shouldDisplayAvatarItemForOneOtherParticipant;
+
 @end

--- a/Code/Controllers/ATLConversationViewController.m
+++ b/Code/Controllers/ATLConversationViewController.m
@@ -89,6 +89,7 @@ static NSString *const ATLPushNotificationSoundName = @"layerbell.caf";
 {
     _dateDisplayTimeInterval = 60*60;
     _marksMessagesAsRead = YES;
+    _shouldDisplayAvatarItemForOneOtherParticipant = NO;
     _typingParticipantIDs = [NSMutableOrderedSet new];
     _sectionHeaders = [NSHashTable weakObjectsHashTable];
     _sectionFooters = [NSHashTable weakObjectsHashTable];
@@ -202,7 +203,7 @@ static NSString *const ATLPushNotificationSoundName = @"layerbell.caf";
     // Configure avatar image display
     NSMutableSet *otherParticipantIDs = [self.conversation.participants mutableCopy];
     if (self.layerClient.authenticatedUserID) [otherParticipantIDs removeObject:self.layerClient.authenticatedUserID];
-    self.shouldDisplayAvatarItem = otherParticipantIDs.count > 1;
+    self.shouldDisplayAvatarItem = (otherParticipantIDs.count > 1) ? YES : self.shouldDisplayAvatarItemForOneOtherParticipant;
     
     // Configure message bar button enablement
     BOOL shouldEnableButton = self.conversation ? YES : NO;


### PR DESCRIPTION
This is the avatar feature I discussed with @kmahal -- added public property `shouldDisplayAvatarItemForOneOtherParticipant` to `ATLConversationViewcontroller`.  Setting this property to YES will cause avatars to be shown even when there is only one other participant (besides the authenticated user) in the conversation.