### PR TITLE
Bug/apps 1579 avatar item choices

### DIFF
--- a/Code/Protocols/ATLAvatarItem.h
+++ b/Code/Protocols/ATLAvatarItem.h
@@ -22,11 +22,10 @@
 
 /**
  @abstract Objects conforming to the `ATLAvatarItem` protocol will be used to display images or
- initials in a `ATLAvatarImageView`.
+ initials in a `ATLAvatarImageView`.  The objects can return `nil` if they do not want to use the
+ specific property.
  */
 @protocol ATLAvatarItem <NSObject>
-
-@optional
 
 /**
  @abstract Returns the image URL for an avatar image for the receiver.

--- a/Code/Views/ATLAvatarImageView.m
+++ b/Code/Views/ATLAvatarImageView.m
@@ -96,8 +96,10 @@ NSString *const ATLAvatarImageViewAccessibilityLabel = @"ATLAvatarImageViewAcces
 - (void)setAvatarItem:(id<ATLAvatarItem>)avatarItem
 {
     if ([avatarItem avatarImageURL]) {
+        self.initialsLabel = nil;
         [self loadAvatarImageWithURL:[avatarItem avatarImageURL]];
     } else if (avatarItem.avatarImage) {
+        self.initialsLabel = nil;
         self.image = avatarItem.avatarImage;
     } else if (avatarItem.avatarInitials) {
         self.image = nil;


### PR DESCRIPTION
This makes the `ATLAvatarItem` non-optional so that developers will receive warnings when they have not implemented the specific getters.