### PR TITLE
Attempt to fix avatar image reloading and reuse issues

### DIFF
--- a/Code/Views/ATLAvatarImageView.h
+++ b/Code/Views/ATLAvatarImageView.h
@@ -57,4 +57,9 @@ extern CGFloat const ATLAvatarImageDiameter;
  */
 @property (nonatomic) UIColor *imageViewBackgroundColor UI_APPEARANCE_SELECTOR;
 
+/**
+ @abstract Sets the avatar item, image view, and initial view to nil in preparation for reuse.
+ */
+- (void)resetView;
+
 @end

--- a/Code/Views/ATLAvatarImageView.m
+++ b/Code/Views/ATLAvatarImageView.m
@@ -93,13 +93,19 @@ NSString *const ATLAvatarImageViewAccessibilityLabel = @"ATLAvatarImageViewAcces
     return CGSizeMake(self.avatarImageViewDiameter, self.avatarImageViewDiameter);
 }
 
+- (void)resetView {
+    self.avatarItem = nil;
+    self.image = nil;
+    self.initialsLabel.text = nil;
+}
+
 - (void)setAvatarItem:(id<ATLAvatarItem>)avatarItem
 {
     if ([avatarItem avatarImageURL]) {
-        self.initialsLabel = nil;
+        self.initialsLabel.text = nil;
         [self loadAvatarImageWithURL:[avatarItem avatarImageURL]];
     } else if (avatarItem.avatarImage) {
-        self.initialsLabel = nil;
+        self.initialsLabel.text = nil;
         self.image = avatarItem.avatarImage;
     } else if (avatarItem.avatarInitials) {
         self.image = nil;
@@ -155,14 +161,17 @@ NSString *const ATLAvatarImageViewAccessibilityLabel = @"ATLAvatarImageViewAcces
             [[[self class] sharedImageCache] setObject:image forKey:stringURL cost:0];
         }
         dispatch_async(dispatch_get_main_queue(), ^{
-            [UIView animateWithDuration:0.2 animations:^{
-                self.alpha = 0.0;
-            } completion:^(BOOL finished) {
-                [UIView animateWithDuration:0.5 animations:^{
-                    self.image = image;
-                    self.alpha = 1.0;
+            // Try to avoid race conditions
+            if ([self.avatarItem avatarImageURL] && [[self.avatarItem avatarImageURL] isEqual:imageURL]) {
+                [UIView animateWithDuration:0.2 animations:^{
+                    self.alpha = 0.0;
+                } completion:^(BOOL finished) {
+                    [UIView animateWithDuration:0.5 animations:^{
+                        self.image = image;
+                        self.alpha = 1.0;
+                    }];
                 }];
-            }];
+            }
         });
     });
 }

--- a/Code/Views/ATLConversationTableViewCell.m
+++ b/Code/Views/ATLConversationTableViewCell.m
@@ -196,6 +196,7 @@ static CGFloat const ATLChevronIconViewRightPadding = 14.0f;
 - (void)prepareForReuse
 {
     [super prepareForReuse];
+    [self.conversationImageView resetView];
     self.conversationImageView.hidden = YES;
     [self setNeedsUpdateConstraints];
 }

--- a/Code/Views/ATLMessageCollectionViewCell.m
+++ b/Code/Views/ATLMessageCollectionViewCell.m
@@ -100,6 +100,7 @@ CGFloat const ATLMessageCellHorizontalMargin = 16.0f;
     // Remove self from any previously assigned LYRProgress instance.
     self.progress.delegate = nil;
     self.lastProgressFractionCompleted = 0;
+    [self.avatarImageView resetView];
     [self.bubbleView prepareForReuse];
 }
 

--- a/Code/Views/ATLParticipantTableViewCell.m
+++ b/Code/Views/ATLParticipantTableViewCell.m
@@ -78,6 +78,7 @@
 {
     [super prepareForReuse];
     self.accessoryView = nil;
+    [self.avatarImageView resetView];
 }
 
 - (void)setHighlighted:(BOOL)highlighted animated:(BOOL)animated


### PR DESCRIPTION
- Added a "resetView" function to ATLAvatarImageView
- Use the function in "prepareForReuse" for all of the cells that it's in
- Change the setting to nil to the label's text rather than the label itself
- Add a comparison between the image URL fetched and the current URL when we're about to set it