### PR TITLE
Expose -initWithLayerClient: method to allow for sub-classing while being able to call the super initialisation

### DIFF
--- a/Code/Controllers/ATLConversationListViewController.h
+++ b/Code/Controllers/ATLConversationListViewController.h
@@ -145,6 +145,13 @@
  */
 + (instancetype)conversationListViewControllerWithLayerClient:(LYRClient *)layerClient;
 
+/**
+ @abstract Creates and returns a new conversation list initialized with a given `LYRClient` object.
+ @param layerClient The `LYRClient` object from which conversations will be fetched for display.
+ @return An `LYRConversationListViewController` object.
+ */
+- (instancetype)initWithLayerClient:(LYRClient *)layerClient;
+
 ///-------------------------------------------------------
 /// @name Configuring Layer Client, Delegate & Data Source
 ///-------------------------------------------------------

--- a/Code/Controllers/ATLConversationListViewController.h
+++ b/Code/Controllers/ATLConversationListViewController.h
@@ -150,7 +150,7 @@
  @param layerClient The `LYRClient` object from which conversations will be fetched for display.
  @return An `LYRConversationListViewController` object.
  */
-- (instancetype)initWithLayerClient:(LYRClient *)layerClient;
+- (instancetype)initWithLayerClient:(LYRClient *)layerClient NS_DESIGNATED_INITIALIZER;
 
 ///-------------------------------------------------------
 /// @name Configuring Layer Client, Delegate & Data Source

--- a/Code/Controllers/ATLConversationListViewController.m
+++ b/Code/Controllers/ATLConversationListViewController.m
@@ -51,8 +51,9 @@ NSString *const ATLConversationTableViewAccessibilityIdentifier = @"Conversation
     return [[self alloc] initWithLayerClient:layerClient];
 }
 
-- (id)initWithLayerClient:(LYRClient *)layerClient
+- (instancetype)initWithLayerClient:(LYRClient *)layerClient
 {
+	NSAssert(layerClient, @"Layer Client cannot be nil");
     self = [super initWithStyle:UITableViewStylePlain];
     if (self)  {
         _layerClient = layerClient;

--- a/Code/Controllers/ATLConversationViewController.h
+++ b/Code/Controllers/ATLConversationViewController.h
@@ -180,6 +180,13 @@
 + (instancetype)conversationViewControllerWithLayerClient:(LYRClient *)layerClient;
 
 /**
+ @abstract Creates and returns a new `ATLConversationViewController` initialized with an `LYRClient` object.
+ @param layerClient The `LYRClient` object from which to retrieve the messages for display.
+ @return An `LYRConversationViewController` object.
+ */
+- (instancetype)initWithLayerClient:(LYRClient *)layerClient NS_DESIGNATED_INITIALIZER;
+
+/**
  @abstract The `LYRClient` object used to initialize the controller.
  @discussion If using storyboards, the property must be set explicitly.
  @raises NSInternalInconsistencyException Raised if the value is mutated after the receiver has been presented.

--- a/Code/Controllers/ATLConversationViewController.m
+++ b/Code/Controllers/ATLConversationViewController.m
@@ -64,7 +64,7 @@ static NSString *const ATLDefaultPushAlertText = @"sent you a message.";
     return [[self alloc] initWithLayerClient:layerClient];
 }
 
-- (id)initWithLayerClient:(LYRClient *)layerClient
+- (instancetype)initWithLayerClient:(LYRClient *)layerClient
 {
     self = [super init];
     if (self) {


### PR DESCRIPTION
When creating a sub-class of ``ATLConversationListViewController`` there is no way to call ``super``'s initialiser from the sub-class, since it is not visible. This is a problem, especially in Swift, when making a sub-class which has properties which must be initialised while retaining ``ATLConversationListViewController``'s initialisation (please let me know if I'm not being clear).