### PR TITLE
APPS-1725 - Crash Related to Changes not Being a Dictionary Anymore.

### DIFF
--- a/Atlas.podspec
+++ b/Atlas.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name                        = "Atlas"
-  s.version                     = '1.0.6'
+  s.version                     = '1.0.8'
   s.summary                     = "Atlas is a library of communications user interface components integrated with LayerKit."
   s.homepage                    = 'https://atlas.layer.com/'
   s.social_media_url            = 'http://twitter.com/layer'
@@ -18,5 +18,5 @@ Pod::Spec.new do |s|
   s.header_mappings_dir         = 'Code'
   s.ios.frameworks              = %w{UIKit CoreLocation MobileCoreServices}
   s.ios.deployment_target       = '7.0'
-  s.dependency                  'LayerKit', '>= 0.13.0'
+  s.dependency                  'LayerKit', '>= 0.13.3'
 end

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 # Atlas Changelog
 
-## 1.07
+## 1.0.8
+
+### Enhancements
+
+* Updated change notification handling code due to LayerKit library upgrade to v0.13.3, which has some braking changes in change notifications dictionary.
+
+## 1.0.7
 
 ### Public API Changes
 

--- a/Code/Atlas.m
+++ b/Code/Atlas.m
@@ -20,4 +20,4 @@
 
 #import "Atlas.h"
 
-NSString *const ATLVersionString = @"1.0.6";
+NSString *const ATLVersionString = @"1.0.8";

--- a/Code/Controllers/ATLConversationViewController.m
+++ b/Code/Controllers/ATLConversationViewController.m
@@ -738,14 +738,11 @@ static NSString *const ATLDefaultPushAlertText = @"sent you a message.";
     if (![notification.object isEqual:self.layerClient]) return;
     
     NSArray *changes = notification.userInfo[LYRClientObjectChangesUserInfoKey];
-    for (NSDictionary *change in changes) {
-        
-        id changedObject = change[LYRObjectChangeObjectKey];
-        if (![changedObject isEqual:self.conversation]) continue;
-        
-        LYRObjectChangeType changeType = [change[LYRObjectChangeTypeKey] integerValue];
-        NSString *changedProperty = change[LYRObjectChangePropertyKey];
-        if (changeType == LYRObjectChangeTypeUpdate && [changedProperty isEqualToString:@"participants"]) {
+    for (LYRObjectChange *change in changes) {
+        if (![change.object isEqual:self.conversation]) {
+            continue;
+        }
+        if (change.type == LYRObjectChangeTypeUpdate && [change.property isEqualToString:@"participants"]) {
             [self configureControllerForChangedParticipants];
             break;
         }

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,13 +1,13 @@
 PODS:
-  - Atlas (1.0.6):
-    - LayerKit (>= 0.13.0)
+  - Atlas (1.0.8):
+    - LayerKit (>= 0.13.3)
   - Expecta (1.0.0)
-  - KIF (3.2.2):
-    - KIF/XCTest (= 3.2.2)
-  - KIF/XCTest (3.2.2)
+  - KIF (3.2.3):
+    - KIF/XCTest (= 3.2.3)
+  - KIF/XCTest (3.2.3)
   - KIFViewControllerActions (1.0.0):
     - KIF (>= 2.0.0)
-  - LayerKit (0.13.2)
+  - LayerKit (0.13.3)
   - LYRCountDownLatch (0.9.0)
   - OCMock (3.1.2)
 
@@ -22,7 +22,7 @@ DEPENDENCIES:
 
 EXTERNAL SOURCES:
   Atlas:
-    :path: "."
+    :path: .
   KIFViewControllerActions:
     :git: https://github.com/blakewatters/KIFViewControllerActions.git
   LYRCountDownLatch:
@@ -37,12 +37,12 @@ CHECKOUT OPTIONS:
     :git: https://github.com/layerhq/LYRCountDownLatch.git
 
 SPEC CHECKSUMS:
-  Atlas: 8c1ded7ff0d3bdcdb49934e2f3cb01525fb977d1
+  Atlas: 8ded03b20e8f2ffc3383983468a304d4ceb50d6b
   Expecta: 32604574add2c46a36f8d2f716b6c5736eb75024
-  KIF: b0bd762b0c7890b04920cf618021d6d4fd5127bd
+  KIF: a94bffe9c97e449e44f8fa481c53243d21309e1e
   KIFViewControllerActions: 73085acd975ebbfc954f7895ca1aaa9faa36b3c6
-  LayerKit: 5a5cdfed55b3c56e7a6bb23323ecca1ad1e6183f
+  LayerKit: 212b87bdaa7e3592b7188952e2211404a2f59614
   LYRCountDownLatch: 72a444f729ca5a8c6157c0b58f335a44e6702b48
   OCMock: a10ea9f0a6e921651f96f78b6faee95ebc813b92
 
-COCOAPODS: 0.37.1
+COCOAPODS: 0.37.2


### PR DESCRIPTION
Fixes a crash where `-[ATLConversationViewController layerClientObjectsDidChange:]` still expects changes to be packed in an `NSDictionary`, when LayerKit v0.13.3 hands out concrete objects.