### PR TITLE
Keep input text color, when adding media attachment.

### DIFF
--- a/Code/Views/ATLMessageInputToolbar.m
+++ b/Code/Views/ATLMessageInputToolbar.m
@@ -198,6 +198,8 @@ static CGFloat const ATLButtonHeight = 28.0f;
 
     NSMutableAttributedString *attachmentString = [[NSAttributedString attributedStringWithAttachment:mediaAttachment] mutableCopy];
     [attachmentString addAttribute:NSFontAttributeName value:textView.font range:NSMakeRange(0, attachmentString.length)];
+    [attachmentString addAttribute:NSForegroundColorAttributeName value:textView.textColor range:NSMakeRange(0, attachmentString.length)];
+
     [attributedString appendAttributedString:attachmentString];
     [attributedString appendAttributedString:lineBreak];
 


### PR DESCRIPTION
Similarly to how the set font is kept, keep the same font color for the attributed string when inserting a media attachment.