### PR TITLE
Fix issues with custom font and color in media attachments.

### DIFF
--- a/Code/Views/ATLMessageInputToolbar.m
+++ b/Code/Views/ATLMessageInputToolbar.m
@@ -197,9 +197,11 @@ static CGFloat const ATLButtonHeight = 28.0f;
     }
 
     NSMutableAttributedString *attachmentString = [[NSAttributedString attributedStringWithAttachment:mediaAttachment] mutableCopy];
-    [attachmentString addAttribute:NSFontAttributeName value:textView.font range:NSMakeRange(0, attachmentString.length)];
     [attributedString appendAttributedString:attachmentString];
     [attributedString appendAttributedString:lineBreak];
+    
+    [attributedString addAttribute:NSFontAttributeName value:textView.font range:NSMakeRange(0, attributedString.length)];
+    [attributedString addAttribute:NSForegroundColorAttributeName value:textView.textColor range:NSMakeRange(0, attributedString.length)];
 
     textView.attributedText = attributedString;
     if ([self.inputToolBarDelegate respondsToSelector:@selector(messageInputToolbarDidType:)]) {

--- a/Code/Views/ATLMessageInputToolbar.m
+++ b/Code/Views/ATLMessageInputToolbar.m
@@ -199,7 +199,6 @@ static CGFloat const ATLButtonHeight = 28.0f;
     NSMutableAttributedString *attachmentString = [[NSAttributedString attributedStringWithAttachment:mediaAttachment] mutableCopy];
     [attributedString appendAttributedString:attachmentString];
     [attributedString appendAttributedString:lineBreak];
-    
     [attributedString addAttribute:NSFontAttributeName value:textView.font range:NSMakeRange(0, attributedString.length)];
     [attributedString addAttribute:NSForegroundColorAttributeName value:textView.textColor range:NSMakeRange(0, attributedString.length)];
 


### PR DESCRIPTION
When adding a media attachment with a custom font color and color, then deleting it the text field would revert to the old color because the first item in the attributed string was not styled.

1) Set color here so custom color continues on just as the font works
2) Apply styling to entire string including the newline, to fix the fact that when only the newline remained it would revert the setting of the textView.