### PR TITLE
Allow collectionview headers to display sender.name instead of defaulting to unknown user

### DIFF
--- a/Code/Controllers/ATLConversationViewController.m
+++ b/Code/Controllers/ATLConversationViewController.m
@@ -1245,8 +1245,13 @@ static NSString *const ATLDefaultPushAlertText = @"sent you a message.";
 
 - (NSString *)participantNameForMessage:(LYRMessage *)message
 {
-    id<ATLParticipant> participant = [self participantForIdentifier:message.sender.userID];
-    NSString *participantName = participant.fullName ?: @"Unknown User";
+    NSString *participantName;
+    if (message.sender.userID) {
+        id<ATLParticipant> participant = [self participantForIdentifier:message.sender.userID];
+        participantName = participant.fullName ?: @"Unknown User";
+    } else {
+        participantName = message.sender.name;
+    }
     return participantName;
 }
 

--- a/Code/Views/ATLConversationCollectionViewHeader.m
+++ b/Code/Views/ATLConversationCollectionViewHeader.m
@@ -85,6 +85,7 @@ CGFloat const ATLConversationViewHeaderEmptyHeight = 1;
     self.participantLabel.font = _participantLabelFont;
     self.participantLabel.textColor = _participantLabelTextColor;
     self.participantLabel.translatesAutoresizingMaskIntoConstraints = NO;
+    self.participantLabel.accessibilityLabel = ATLConversationViewHeaderIdentifier;
     [self addSubview:self.participantLabel];
     
     [self configureDateLabelConstraints];

--- a/Examples/Mocks/LYRClientMock.h
+++ b/Examples/Mocks/LYRClientMock.h
@@ -42,6 +42,7 @@ extern NSString *const LYRMockObjectChangeChangeTypeKey;
 
 - (LYRConversationMock *)newConversationWithParticipants:(NSSet *)participants options:(NSDictionary *)options error:(NSError **)error;
 - (LYRMessageMock *)newMessageWithParts:(NSArray *)messageParts options:(NSDictionary *)options error:(NSError **)error;
+- (LYRMessageMock *)newPlatformMessageWithParts:(NSArray *)messageParts senderName:(NSString *)senderName options:(NSDictionary *)options error:(NSError **)error;
 - (NSOrderedSet *)executeQuery:(LYRQuery *)query error:(NSError **)error;
 - (NSUInteger)countForQuery:(LYRQuery *)query error:(NSError **)error;
 - (LYRQueryControllerMock *)queryControllerWithQuery:(LYRQuery *)query;

--- a/Examples/Mocks/LYRClientMock.m
+++ b/Examples/Mocks/LYRClientMock.m
@@ -75,6 +75,11 @@ NSString *const LYRMockObjectChangeChangeTypeKey = @"mockObjectChangeChangeTypeK
     return [LYRMessageMock newMessageWithParts:messageParts senderID:self.authenticatedUserID];
 }
 
+- (LYRMessageMock *)newPlatformMessageWithParts:(NSArray *)messageParts senderName:(NSString *)senderName options:(NSDictionary *)options error:(NSError *__autoreleasing *)error
+{
+    return [LYRMessageMock newMessageWithParts:messageParts senderName:senderName];
+}
+
 - (NSOrderedSet *)executeQuery:(LYRQuery *)query error:(NSError *__autoreleasing *)error
 {
     return [[LYRMockContentStore sharedStore] fetchObjectsWithClass:query.queryableClass predicate:query.predicate sortDescriptior:query.sortDescriptors];

--- a/Examples/Mocks/LYRMessageMock.h
+++ b/Examples/Mocks/LYRMessageMock.h
@@ -44,6 +44,8 @@
 
 + (instancetype)newMessageWithParts:(NSArray *)messageParts senderID:(NSString *)senderID;
 
++ (instancetype)newMessageWithParts:(NSArray *)messageParts senderName:(NSString *)senderName;
+
 - (BOOL)markAsRead:(NSError **)error;
 
 - (BOOL)delete:(LYRDeletionMode)deletionMode error:(NSError **)error;

--- a/Examples/Mocks/LYRMessageMock.m
+++ b/Examples/Mocks/LYRMessageMock.m
@@ -46,9 +46,30 @@
     return self;    
 }
 
+- (id)initWithMessageParts:(NSArray *)messageParts senderName:(NSString *)senderName
+{
+    self = [super init];
+    if (self) {
+        _parts = messageParts;
+        _sender = [LYRActorMock new];
+        _sender.name = senderName;
+    }
+    return self;
+}
+
 + (instancetype)newMessageWithParts:(NSArray *)messageParts senderID:(NSString *)senderID
 {
     LYRMessageMock *mock = [[self alloc] initWithMessageParts:messageParts senderID:senderID];
+    mock.identifier = [NSURL URLWithString:[[NSUUID UUID] UUIDString]];
+    mock.isSent = NO;
+    mock.isDeleted = NO;
+    mock.isUnread = YES;
+    return mock;
+}
+
++ (instancetype)newMessageWithParts:(NSArray *)messageParts senderName:(NSString *)senderName
+{
+    LYRMessageMock *mock = [[self alloc] initWithMessageParts:messageParts senderName:senderName];
     mock.identifier = [NSURL URLWithString:[[NSUUID UUID] UUIDString]];
     mock.isSent = NO;
     mock.isDeleted = NO;

--- a/Tests/ATLConversationViewControllerTest.m
+++ b/Tests/ATLConversationViewControllerTest.m
@@ -275,6 +275,42 @@ extern NSString *const ATLMessageInputToolbarSendButton;
     [tester waitForViewWithAccessibilityLabel:ATLAvatarImageViewAccessibilityLabel];
 }
 
+- (void)testToVerifySenderNameIsDisplayedInGroupConversation
+{
+    ATLUserMock *mockUser2 = [ATLUserMock userWithMockUserName:ATLMockUserNameKevin];
+    LYRClientMock *layerClient = [LYRClientMock layerClientMockWithAuthenticatedUserID:mockUser2.participantIdentifier];
+    [self.conversation addParticipants:[NSSet setWithObject:mockUser2.participantIdentifier] error:nil];
+    
+    LYRMessagePartMock *part = [LYRMessagePartMock messagePartWithText:@"Test"];
+    LYRMessageMock *message = [layerClient newMessageWithParts:@[part] options:nil error:nil];
+    [self.conversation sendMessage:message error:nil];
+    
+    [self setupConversationViewController];
+    [self setRootViewController:self.viewController];
+    
+    [tester waitForTimeInterval:10];
+    UILabel *label = (UILabel *)[tester waitForViewWithAccessibilityLabel:ATLConversationViewHeaderIdentifier];
+    expect(label.text).to.equal(mockUser2.fullName);
+}
+
+- (void)testToVerifyPlatformMessageSenderNameIsDisplayedInGroupConversation
+{
+    ATLUserMock *mockUser2 = [ATLUserMock userWithMockUserName:ATLMockUserNameKevin];
+    LYRClientMock *layerClient = [LYRClientMock layerClientMockWithAuthenticatedUserID:mockUser2.participantIdentifier];
+    [self.conversation addParticipants:[NSSet setWithObject:mockUser2.participantIdentifier] error:nil];
+    
+    LYRMessagePartMock *part = [LYRMessagePartMock messagePartWithText:@"Test"];
+    LYRMessageMock *message = [layerClient newPlatformMessageWithParts:@[part] senderName:@"Platform" options:nil error:nil];
+    [self.conversation sendMessage:message error:nil];
+    
+    [self setupConversationViewController];
+    [self setRootViewController:self.viewController];
+    
+    [tester waitForTimeInterval:10];
+    UILabel *label = (UILabel *)[tester waitForViewWithAccessibilityLabel:ATLConversationViewHeaderIdentifier];
+    expect(label.text).to.equal(@"Platform");
+}
+
 - (void)testToVerifyCustomAvatarImageDiameter
 {
     [[ATLAvatarImageView appearance] setAvatarImageViewDiameter:40];


### PR DESCRIPTION
This pull request allows the `ATLConversationViewController` to display a system message in a conversation by checking which value exists before grabbing the required string value.