### PR TITLE
Fix ATLConversationViewController.m

### DIFF
--- a/Code/Controllers/ATLConversationViewController.m
+++ b/Code/Controllers/ATLConversationViewController.m
@@ -1112,6 +1112,10 @@ static NSString *const ATLDefaultPushAlertText = @"sent you a message.";
 
 - (void)queryControllerDidChangeContent:(LYRQueryController *)queryController
 {
+    if (!self.collectionView) {
+        return;
+    }
+    
     if (self.conversationDataSource.isExpandingPaginationWindow) {
         self.showingMoreMessagesIndicator = [self.conversationDataSource moreMessagesAvailable];
         [self reloadCollectionViewAdjustingForContentHeightChange];


### PR DESCRIPTION
FIx `queryControllerDidChangeContent` to prevent crashes from uninstantiated `self.collectionView`.  Refer to issue #873.