### PR TITLE
Feature/apps 1843 caching media attachments

### DIFF
--- a/Code/Controllers/ATLConversationViewController.m
+++ b/Code/Controllers/ATLConversationViewController.m
@@ -190,11 +190,10 @@ static NSString *const ATLDefaultPushAlertText = @"sent you a message.";
     NSArray *mediaAttachments = [[[self class] sharedMediaAttachmentCache] objectForKey:self.conversation.identifier];
     for (int i = 0; i < mediaAttachments.count; i++) {
         ATLMediaAttachment *attachment = [mediaAttachments objectAtIndex:i];
-        BOOL shouldHaveLineBreak = i < mediaAttachments.count - 1;
+        BOOL shouldHaveLineBreak = (i < mediaAttachments.count - 1) || !(attachment.mediaMIMEType == ATLMIMETypeTextPlain);
         [self.messageInputToolbar insertMediaAttachment:attachment withEndLineBreak:shouldHaveLineBreak];
     }
     [[[self class] sharedMediaAttachmentCache] removeObjectForKey:self.conversation.identifier];
-    [self.messageInputToolbar configureRightAccessoryButtonState];
 }
 
 #pragma mark - Conversation Data Source Setup

--- a/Code/Views/ATLMessageInputToolbar.h
+++ b/Code/Views/ATLMessageInputToolbar.h
@@ -82,7 +82,15 @@ extern NSString *const ATLMessageInputToolbarAccessibilityLabel;
  fit the thumbnail content. The image will also be cached and is accessible via the mediaAttachments
  property.
  */
-- (void)insertMediaAttachment:(ATLMediaAttachment *)mediaAttachment;
+- (void)insertMediaAttachment:(ATLMediaAttachment *)mediaAttachment withEndLineBreak:(BOOL)endLineBreak;
+
+/**
+ @abstract Configures the right accessory button directly without requiring a text change.
+ @discussion When inserting `ATLMediaAttachment` objects in `viewWillAppear:`, the right accessory
+ button doesn't update correctly because it normally updates from the textview changes.  This gives
+ the ability to simulate native state change without needing to directly access the textview.
+ */
+- (void)configureRightAccessoryButtonState;
 
 //-----------------------------
 // UI Customization

--- a/Code/Views/ATLMessageInputToolbar.h
+++ b/Code/Views/ATLMessageInputToolbar.h
@@ -78,6 +78,7 @@ extern NSString *const ATLMessageInputToolbarAccessibilityLabel;
 /**
  @abstract Inserts the mediaAttachment as an attributed text attachment which is inlined with text.
  @param mediaAttachment The `ATLMediaAttachment` instance containing information about the media.
+ @param endLineBreak A `BOOL` which if `YES` inserts a new line after the media attachment insertion.
  @discussion The view will automatically resize the attachment's thumbnail and itself to comfortably
  fit the thumbnail content. The image will also be cached and is accessible via the mediaAttachments
  property.

--- a/Code/Views/ATLMessageInputToolbar.h
+++ b/Code/Views/ATLMessageInputToolbar.h
@@ -85,14 +85,6 @@ extern NSString *const ATLMessageInputToolbarAccessibilityLabel;
  */
 - (void)insertMediaAttachment:(ATLMediaAttachment *)mediaAttachment withEndLineBreak:(BOOL)endLineBreak;
 
-/**
- @abstract Configures the right accessory button directly without requiring a text change.
- @discussion When inserting `ATLMediaAttachment` objects in `viewWillAppear:`, the right accessory
- button doesn't update correctly because it normally updates from the textview changes.  This gives
- the ability to simulate native state change without needing to directly access the textview.
- */
-- (void)configureRightAccessoryButtonState;
-
 //-----------------------------
 // UI Customization
 //-----------------------------

--- a/Code/Views/ATLMessageInputToolbar.m
+++ b/Code/Views/ATLMessageInputToolbar.m
@@ -171,7 +171,7 @@ static CGFloat const ATLButtonHeight = 28.0f;
             ATLMediaAttachment *mediaAttachment = [ATLMediaAttachment mediaAttachmentWithImage:image
                                                                                       metadata:nil
                                                                                  thumbnailSize:ATLDefaultThumbnailSize];
-            [self insertMediaAttachment:mediaAttachment];
+            [self insertMediaAttachment:mediaAttachment withEndLineBreak:YES];
         }
         return;
     }
@@ -186,7 +186,7 @@ static CGFloat const ATLButtonHeight = 28.0f;
     [self setNeedsLayout];
 }
 
-- (void)insertMediaAttachment:(ATLMediaAttachment *)mediaAttachment
+- (void)insertMediaAttachment:(ATLMediaAttachment *)mediaAttachment withEndLineBreak:(BOOL)endLineBreak;
 {
     UITextView *textView = self.textInputView;
 
@@ -196,9 +196,11 @@ static CGFloat const ATLButtonHeight = 28.0f;
         [attributedString appendAttributedString:lineBreak];
     }
 
-    NSMutableAttributedString *attachmentString = [[NSAttributedString attributedStringWithAttachment:mediaAttachment] mutableCopy];
+    NSMutableAttributedString *attachmentString = (mediaAttachment.mediaMIMEType == ATLMIMETypeTextPlain) ? [[NSAttributedString alloc] initWithString:mediaAttachment.textRepresentation] : [[NSAttributedString attributedStringWithAttachment:mediaAttachment] mutableCopy];
     [attributedString appendAttributedString:attachmentString];
-    [attributedString appendAttributedString:lineBreak];
+    if (endLineBreak) {
+        [attributedString appendAttributedString:lineBreak];
+    }
     [attributedString addAttribute:NSFontAttributeName value:textView.font range:NSMakeRange(0, attributedString.length)];
     if (textView.textColor) {
         [attributedString addAttribute:NSForegroundColorAttributeName value:textView.textColor range:NSMakeRange(0, attributedString.length)];

--- a/Examples/Mocks/LYRConversationMock.m
+++ b/Examples/Mocks/LYRConversationMock.m
@@ -67,6 +67,7 @@ NSData *MediaAttachmentDataFromInputStream(NSInputStream *inputStream)
 {
     LYRConversationMock *mock = [[self alloc] initWithParticipants:participants];
     mock.metadata = [options valueForKey:LYRConversationOptionsMetadataKey];
+    mock.identifier = [NSURL URLWithString:@"test"];
     return mock;
 }
 

--- a/Tests/ATLConversationViewControllerTest.m
+++ b/Tests/ATLConversationViewControllerTest.m
@@ -97,6 +97,26 @@ extern NSString *const ATLMessageInputToolbarSendButton;
     [self sendPhotoMessage];
 }
 
+- (void)testToVerifyCachingMediaAttachments
+{
+    [self setupConversationViewController];
+    UIViewController *baseViewController = [UIViewController new];
+    [self setRootViewController:baseViewController];
+    [baseViewController.navigationController pushViewController:self.viewController animated:YES];
+    [tester waitForAnimationsToFinish];
+
+    ATLMessageInputToolbar *toolBar = (ATLMessageInputToolbar *)[tester waitForViewWithAccessibilityLabel:@"Message Input Toolbar"];
+    [toolBar.textInputView setText:@"Test"];
+    self.viewController = nil;
+    [baseViewController.navigationController dismissViewControllerAnimated:YES completion:nil];
+    [tester waitForAnimationsToFinish];
+
+    [self setupConversationViewController];
+    [baseViewController.navigationController pushViewController:self.viewController animated:YES];
+    toolBar = (ATLMessageInputToolbar *)[tester waitForViewWithAccessibilityLabel:@"Message Input Toolbar"];
+    expect(toolBar.textInputView.text).to.equal(@"Test");
+}
+
 #pragma mark - ATLConversationViewControllerDelegate
 
 //- (void)conversationViewController:(ATLConversationViewController *)viewController didSendMessage:(LYRMessage *)message;

--- a/Tests/ATLMessageInputBarTest.m
+++ b/Tests/ATLMessageInputBarTest.m
@@ -24,6 +24,7 @@
 #import "ATLSampleConversationViewController.h"
 #import "ATLMediaAttachment.h"
 #import "ATLConstants.h"
+#import "ATLTestUtilities.h"
 
 @interface ATLConversationViewController ()
 
@@ -198,9 +199,9 @@ extern NSString *const ATLMessageInputToolbarSendButton;
     
     [tester enterText:testText intoViewWithAccessibilityLabel:ATLMessageInputToolbarTextInputView];
     
-    UIImage *image = [UIImage imageNamed:@"test-logo"];
+    UIImage *image = ATLTestAttachmentMakeImageWithSize(CGSizeMake(1024, 512));
     ATLMediaAttachment *imageAttachment = [ATLMediaAttachment mediaAttachmentWithImage:image metadata:nil thumbnailSize:100];
-    [toolBar insertMediaAttachment:imageAttachment];
+    [toolBar insertMediaAttachment:imageAttachment withEndLineBreak:YES];
     [tester tapViewWithAccessibilityLabel:ATLMessageInputToolbarSendButton];
     [delegateMock verify];
 }
@@ -222,10 +223,10 @@ extern NSString *const ATLMessageInputToolbarSendButton;
     }] messageInputToolbar:toolBar didTapRightAccessoryButton:[OCMArg any]];
     
     [tester enterText:testText intoViewWithAccessibilityLabel:ATLMessageInputToolbarTextInputView];
-    UIImage *image = [UIImage imageNamed:@"test-logo"];
+    UIImage *image = ATLTestAttachmentMakeImageWithSize(CGSizeMake(1024, 512));
     ATLMediaAttachment *imageAttachment = [ATLMediaAttachment mediaAttachmentWithImage:image metadata:nil thumbnailSize:100];
-    [toolBar insertMediaAttachment:imageAttachment];
-    [toolBar insertMediaAttachment:imageAttachment];
+    [toolBar insertMediaAttachment:imageAttachment withEndLineBreak:YES];
+    [toolBar insertMediaAttachment:imageAttachment withEndLineBreak:YES];
     [tester tapViewWithAccessibilityLabel:ATLMessageInputToolbarSendButton];
     [delegateMock verify];
 }
@@ -247,13 +248,13 @@ extern NSString *const ATLMessageInputToolbarSendButton;
         expect([parts objectAtIndex:4]).to.beKindOf([ATLMediaAttachment class]);
     }] messageInputToolbar:toolBar didTapRightAccessoryButton:[OCMArg any]];
     
-    UIImage *image = [UIImage imageNamed:@"test-logo"];
+    UIImage *image = ATLTestAttachmentMakeImageWithSize(CGSizeMake(1024, 512));
     ATLMediaAttachment *imageAttachment = [ATLMediaAttachment mediaAttachmentWithImage:image metadata:nil thumbnailSize:100];
-    [toolBar insertMediaAttachment:imageAttachment];
-    [toolBar insertMediaAttachment:imageAttachment];
-    [toolBar insertMediaAttachment:imageAttachment];
-    [toolBar insertMediaAttachment:imageAttachment];
-    [toolBar insertMediaAttachment:imageAttachment];
+    [toolBar insertMediaAttachment:imageAttachment withEndLineBreak:YES];
+    [toolBar insertMediaAttachment:imageAttachment withEndLineBreak:YES];
+    [toolBar insertMediaAttachment:imageAttachment withEndLineBreak:YES];
+    [toolBar insertMediaAttachment:imageAttachment withEndLineBreak:YES];
+    [toolBar insertMediaAttachment:imageAttachment withEndLineBreak:YES];
     
     [tester tapViewWithAccessibilityLabel:ATLMessageInputToolbarSendButton];
     [delegateMock verify];
@@ -265,9 +266,9 @@ extern NSString *const ATLMessageInputToolbarSendButton;
     ATLMessageInputToolbar *toolBar = (ATLMessageInputToolbar *)[tester waitForViewWithAccessibilityLabel:@"Message Input Toolbar"];
     UIFont *font = toolBar.textInputView.font;
     
-    UIImage *image = [UIImage imageNamed:@"test-logo"];
+    UIImage *image = ATLTestAttachmentMakeImageWithSize(CGSizeMake(1024, 512));
     ATLMediaAttachment *imageAttachment = [ATLMediaAttachment mediaAttachmentWithImage:image metadata:nil thumbnailSize:100];
-    [toolBar insertMediaAttachment:imageAttachment];
+    [toolBar insertMediaAttachment:imageAttachment withEndLineBreak:YES];
 
     [tester clearTextFromViewWithAccessibilityLabel:ATLMessageInputToolbarTextInputView];
     expect(font).to.equal(toolBar.textInputView.font);
@@ -277,7 +278,7 @@ extern NSString *const ATLMessageInputToolbarSendButton;
 {
     [self setRootViewController];
     ATLMessageInputToolbar *toolBar = (ATLMessageInputToolbar *)[tester waitForViewWithAccessibilityLabel:@"Message Input Toolbar"];
-    UIImage *image = [UIImage imageNamed:@"test-logo"];
+    UIImage *image = ATLTestAttachmentMakeImageWithSize(CGSizeMake(1024, 512));
     toolBar.rightAccessoryImage = image;
     expect(toolBar.rightAccessoryButton.imageView.image).to.equal(image);
     expect(toolBar.rightAccessoryButton.enabled).to.beTruthy();
@@ -300,7 +301,7 @@ extern NSString *const ATLMessageInputToolbarSendButton;
 {
     [self setRootViewController];
     ATLMessageInputToolbar *toolBar = (ATLMessageInputToolbar *)[tester waitForViewWithAccessibilityLabel:@"Message Input Toolbar"];
-    UIImage *image = [UIImage imageNamed:@"test-logo"];
+    UIImage *image = ATLTestAttachmentMakeImageWithSize(CGSizeMake(1024, 512));
     toolBar.rightAccessoryImage = image;
     toolBar.leftAccessoryImage = image;
     


### PR DESCRIPTION
This PR allows the `ATLConversationViewController` to cache any unsent media attachments when deallocating and inserts them again when the conversation is reshown.