### PR TITLE
delegating datasource creation to queue off the main thread

### DIFF
--- a/Code/Controllers/ATLBaseConversationViewController.m
+++ b/Code/Controllers/ATLBaseConversationViewController.m
@@ -110,6 +110,12 @@ static CGFloat const ATLMaxScrollDistanceFromBottom = 150;
     [self updateBottomCollectionViewInset];
 }
 
+- (void)viewDidAppear:(BOOL)animated
+{
+    [super viewDidAppear:animated];
+    self.firstAppearance = YES;
+}
+
 - (void)viewDidLayoutSubviews
 {
     [super viewDidLayoutSubviews];
@@ -121,7 +127,6 @@ static CGFloat const ATLMaxScrollDistanceFromBottom = 150;
     }
     
     if (self.isFirstAppearance) {
-        self.firstAppearance = NO;
         // We use the content size of the actual collection view when calculating the ammount to scroll. Hence, we layout the collection view before scrolling to the bottom.
         [self.view layoutIfNeeded];
         [self scrollToBottomAnimated:NO];

--- a/Code/Models/ATLConversationDataSource.m
+++ b/Code/Models/ATLConversationDataSource.m
@@ -46,10 +46,6 @@ NSInteger const ATLQueryControllerPaginationWindow = 30;
         _queryController = [layerClient queryControllerWithQuery:query];
         _queryController.updatableProperties = [NSSet setWithObjects:@"parts.transferStatus", @"recipientStatusByUserID", @"sentAt", nil];
         _queryController.paginationWindow = -numberOfMessagesToDisplay;
-        
-        NSError *error = nil;
-        BOOL success = [_queryController execute:&error];
-        if (!success) NSLog(@"LayerKit failed to execute query with error: %@", error);
     }
     return self;
 }

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -7,7 +7,7 @@ PODS:
   - KIF/XCTest (3.2.3)
   - KIFViewControllerActions (1.0.0):
     - KIF (>= 2.0.0)
-  - LayerKit (0.14.2)
+  - LayerKit (0.15.0)
   - LYRCountDownLatch (0.9.0)
   - OCMock (3.1.2)
 
@@ -22,7 +22,7 @@ DEPENDENCIES:
 
 EXTERNAL SOURCES:
   Atlas:
-    :path: .
+    :path: "."
   KIFViewControllerActions:
     :git: https://github.com/blakewatters/KIFViewControllerActions.git
   LYRCountDownLatch:
@@ -41,8 +41,8 @@ SPEC CHECKSUMS:
   Expecta: 32604574add2c46a36f8d2f716b6c5736eb75024
   KIF: a94bffe9c97e449e44f8fa481c53243d21309e1e
   KIFViewControllerActions: 73085acd975ebbfc954f7895ca1aaa9faa36b3c6
-  LayerKit: 1e8d44e8266be19ffaaf90bdb1fd8becca337a16
+  LayerKit: ac8c5c227a06e2ea5e042303b80e931a8ffe3568
   LYRCountDownLatch: 72a444f729ca5a8c6157c0b58f335a44e6702b48
   OCMock: a10ea9f0a6e921651f96f78b6faee95ebc813b92
 
-COCOAPODS: 0.36.0
+COCOAPODS: 0.37.1


### PR DESCRIPTION
This PR executes the `ATLConversationViewController` data source's querycontroller on a background thread to improve perceived performance.