### PR TITLE
ATLConversationViewController delegate for cell customization

### DIFF
--- a/Atlas.podspec
+++ b/Atlas.podspec
@@ -18,5 +18,5 @@ Pod::Spec.new do |s|
   s.header_mappings_dir         = 'Code'
   s.ios.frameworks              = %w{UIKit CoreLocation MobileCoreServices}
   s.ios.deployment_target       = '7.0'
-  s.dependency                  'LayerKit', '>= 0.14.2'
+  s.dependency                  'LayerKit', '>= 0.15.0'
 end

--- a/Code/Controllers/ATLConversationViewController.h
+++ b/Code/Controllers/ATLConversationViewController.h
@@ -69,6 +69,16 @@
 - (CGFloat)conversationViewController:(ATLConversationViewController *)viewController heightForMessage:(LYRMessage *)message withCellWidth:(CGFloat)cellWidth;
 
 /**
+ @abstract Informs the delegate of a cell being configured for the specified message.
+ @param viewController The `ATLConversationViewController` where the message cell will appear.
+ @param cell The `UICollectionViewCell` object that adheres to the `ATLMessagePresenting` protocol that will be displayed in the controller.
+ @param message The `LYRMessage` object that will be displayed in the cell.
+ @discussion Applications should implement this method if they want add further configuration that is not set up during cell initialization, such as gesture recognizers.
+ It is up to the application to typecast the cell to access custom cell properties.
+ */
+- (void)conversationViewController:(ATLConversationViewController *)conversationViewController configureCell:(UICollectionViewCell<ATLMessagePresenting> *)cell forMessage:(LYRMessage *)message;
+
+/**
  @abstract Asks the delegate for an `NSOrderedSet` of `LYRMessage` objects representing an `NSArray` of content parts.
  @param viewController The `ATLConversationViewController` supplying the content parts.
  @param mediaAttachments The array of `ATLMediaAttachment` items supplied via user input into the `messageInputToolbar` property of the controller.

--- a/Code/Controllers/ATLConversationViewController.h
+++ b/Code/Controllers/ATLConversationViewController.h
@@ -71,7 +71,7 @@
 /**
  @abstract Informs the delegate of a cell being configured for the specified message.
  @param viewController The `ATLConversationViewController` where the message cell will appear.
- @param cell The `UICollectionViewCell` object that adheres to the `ATLMessagePresenting` protocol that will be displayed in the controller.
+ @param cell The `UICollectionViewCell` object that confirms to the `ATLMessagePresenting` protocol that will be displayed in the controller.
  @param message The `LYRMessage` object that will be displayed in the cell.
  @discussion Applications should implement this method if they want add further configuration that is not set up during cell initialization, such as gesture recognizers.
  It is up to the application to typecast the cell to access custom cell properties.

--- a/Code/Controllers/ATLConversationViewController.m
+++ b/Code/Controllers/ATLConversationViewController.m
@@ -309,6 +309,9 @@ static NSInteger const ATLPhotoActionSheet = 1000;
     
     UICollectionViewCell<ATLMessagePresenting> *cell =  [self.collectionView dequeueReusableCellWithReuseIdentifier:reuseIdentifier forIndexPath:indexPath];
     [self configureCell:cell forMessage:message indexPath:indexPath];
+    if ([self.delegate respondsToSelector:@selector(conversationViewController:configureCell:forMessage:)]) {
+        [self.delegate conversationViewController:self configureCell:cell forMessage:message];
+    }
     return cell;
 }
 
@@ -415,7 +418,6 @@ static NSInteger const ATLPhotoActionSheet = 1000;
         [cell updateWithSender:nil];
     }
     if (message.isUnread && [[UIApplication sharedApplication] applicationState] == UIApplicationStateActive) {
-        
         [message markAsRead:nil];
     }
 }

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,0 +1,48 @@
+PODS:
+  - Atlas (1.0.10):
+    - LayerKit (>= 0.14.2)
+  - Expecta (1.0.0)
+  - KIF (3.2.3):
+    - KIF/XCTest (= 3.2.3)
+  - KIF/XCTest (3.2.3)
+  - KIFViewControllerActions (1.0.0):
+    - KIF (>= 2.0.0)
+  - LayerKit (0.15.0)
+  - LYRCountDownLatch (0.9.0)
+  - OCMock (3.1.2)
+
+DEPENDENCIES:
+  - Atlas (from `.`)
+  - Expecta
+  - KIF
+  - KIFViewControllerActions (from `https://github.com/blakewatters/KIFViewControllerActions.git`)
+  - LayerKit
+  - LYRCountDownLatch (from `https://github.com/layerhq/LYRCountDownLatch.git`)
+  - OCMock
+
+EXTERNAL SOURCES:
+  Atlas:
+    :path: "."
+  KIFViewControllerActions:
+    :git: https://github.com/blakewatters/KIFViewControllerActions.git
+  LYRCountDownLatch:
+    :git: https://github.com/layerhq/LYRCountDownLatch.git
+
+CHECKOUT OPTIONS:
+  KIFViewControllerActions:
+    :commit: fbcaaaf2a6236c6ed840ce011a44f7e3e1f7570d
+    :git: https://github.com/blakewatters/KIFViewControllerActions.git
+  LYRCountDownLatch:
+    :commit: 02119f855ad14e7fc0dae32bbbf17c735a281cfe
+    :git: https://github.com/layerhq/LYRCountDownLatch.git
+
+SPEC CHECKSUMS:
+  Atlas: ea8e1559810405c4eaa45eef80b813a12235527c
+  Expecta: 32604574add2c46a36f8d2f716b6c5736eb75024
+  KIF: a94bffe9c97e449e44f8fa481c53243d21309e1e
+  KIFViewControllerActions: 73085acd975ebbfc954f7895ca1aaa9faa36b3c6
+  LayerKit: ac8c5c227a06e2ea5e042303b80e931a8ffe3568
+  LYRCountDownLatch: 72a444f729ca5a8c6157c0b58f335a44e6702b48
+  OCMock: a10ea9f0a6e921651f96f78b6faee95ebc813b92
+
+COCOAPODS: 0.37.1

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,6 +1,6 @@
 PODS:
   - Atlas (1.0.10):
-    - LayerKit (>= 0.14.2)
+    - LayerKit (>= 0.15.0)
   - Expecta (1.0.0)
   - KIF (3.2.3):
     - KIF/XCTest (= 3.2.3)
@@ -37,7 +37,7 @@ CHECKOUT OPTIONS:
     :git: https://github.com/layerhq/LYRCountDownLatch.git
 
 SPEC CHECKSUMS:
-  Atlas: ea8e1559810405c4eaa45eef80b813a12235527c
+  Atlas: ea703b0908806c71dec203cb000b9aafae8f7c27
   Expecta: 32604574add2c46a36f8d2f716b6c5736eb75024
   KIF: a94bffe9c97e449e44f8fa481c53243d21309e1e
   KIFViewControllerActions: 73085acd975ebbfc954f7895ca1aaa9faa36b3c6

--- a/Tests/ATLConversationViewControllerTest.m
+++ b/Tests/ATLConversationViewControllerTest.m
@@ -314,6 +314,35 @@ extern NSString *const ATLMessageInputToolbarSendButton;
     [tester waitForViewWithAccessibilityLabel:testMessageText];
 }
 
+//- (void)conversationViewController:(ATLConversationViewController *)conversationViewController configureCell:(UICollectionViewCell<ATLMessagePresenting> *)cell forMessage:(LYRMessage *)message;
+- (void)testToVerifyDelegateIsNotifiedOfCellCreation
+{
+    [self setupConversationViewController];
+    [self setRootViewController:self.viewController];
+    
+    id delegateMock = OCMProtocolMock(@protocol(ATLConversationViewControllerDelegate));
+    self.viewController.delegate = delegateMock;
+    
+    [[[delegateMock expect] andDo:^(NSInvocation *invocation) {
+        ATLConversationViewController *controller;
+        [invocation getArgument:&controller atIndex:2];
+        expect(controller).to.equal(self.viewController);
+        
+        UICollectionViewCell <ATLMessagePresenting> *cell;
+        [invocation getArgument:&cell atIndex:3];
+        expect(cell).to.beKindOf([UICollectionViewCell class]);
+        
+        LYRMessage *message;
+        [invocation getArgument:&message atIndex:4];
+        expect(message).to.beKindOf([LYRMessageMock class]);
+        
+    }] conversationViewController:[OCMArg any] configureCell:[OCMArg any] forMessage:[OCMArg any]];
+    
+    [self sendMessageWithText:@"This is a test"];
+    [tester tapViewWithAccessibilityLabel:@"Message: This is a test"];
+    [delegateMock verify];
+}
+
 - (void)testToVerityControllerDisplaysCorrectDataFromTheDataSource
 {
     [self setupConversationViewController];


### PR DESCRIPTION
Added optional ATLConverstionViewController delegate method to pass delegate cells during initialization for further customization