### PR TITLE
Dismiss UIMenuController on any pan, and fix location data for cached location images

### DIFF
--- a/Code/Views/ATLMessageBubbleView.m
+++ b/Code/Views/ATLMessageBubbleView.m
@@ -42,6 +42,7 @@ typedef NS_ENUM(NSInteger, ATLBubbleViewContentType) {
 @property (nonatomic) UIView *longPressMask;
 @property (nonatomic) CLLocationCoordinate2D locationShown;
 @property (nonatomic) UITapGestureRecognizer *tapGestureRecognizer;
+@property (nonatomic) UIPanGestureRecognizer *panGestureRecognizer;
 @property (nonatomic) NSURL *tappedURL;
 @property (nonatomic) NSLayoutConstraint *imageWidthConstraint;
 @property (nonatomic) MKMapSnapshotter *snapshotter;
@@ -92,6 +93,10 @@ typedef NS_ENUM(NSInteger, ATLBubbleViewContentType) {
         _tapGestureRecognizer = [[UITapGestureRecognizer alloc] initWithTarget:self action:@selector(handleLabelTap:)];
         _tapGestureRecognizer.delegate = self;
         [self.bubbleViewLabel addGestureRecognizer:_tapGestureRecognizer];
+        
+        _panGestureRecognizer = [[UIPanGestureRecognizer alloc] initWithTarget:self action:@selector(handlePan:)];
+        _panGestureRecognizer.delegate = self;
+        [self addGestureRecognizer:_panGestureRecognizer];
 
         UILongPressGestureRecognizer *gestureRecognizer = [[UILongPressGestureRecognizer alloc] initWithTarget:self action:@selector(handleLongPress:)];
         [self addGestureRecognizer:gestureRecognizer];
@@ -312,6 +317,10 @@ typedef NS_ENUM(NSInteger, ATLBubbleViewContentType) {
     }
 }
 
+- (void)handlePan:(UIPanGestureRecognizer *)recognizer {
+    [[UIMenuController sharedMenuController] setMenuVisible:NO animated:YES];
+}
+
 #pragma mark - UIGestureRecognizerDelegate
 
 - (BOOL)gestureRecognizerShouldBegin:(UIGestureRecognizer *)gestureRecognizer
@@ -343,6 +352,14 @@ typedef NS_ENUM(NSInteger, ATLBubbleViewContentType) {
             self.tappedURL = result.URL;
             return YES;
         }
+    }
+    return NO;
+}
+
+- (BOOL)gestureRecognizer:(UIGestureRecognizer *)gestureRecognizer
+shouldRecognizeSimultaneouslyWithGestureRecognizer:(UIGestureRecognizer *)otherGestureRecognizer {
+    if (gestureRecognizer == self.panGestureRecognizer || otherGestureRecognizer == self.panGestureRecognizer) {
+        return YES;
     }
     return NO;
 }

--- a/Code/Views/ATLMessageBubbleView.m
+++ b/Code/Views/ATLMessageBubbleView.m
@@ -141,6 +141,7 @@ typedef NS_ENUM(NSInteger, ATLBubbleViewContentType) {
     NSString *cachedImageIdentifier = [NSString stringWithFormat:@"%f,%f", location.latitude, location.longitude];
     UIImage *cachedImage = [[[self class] sharedCache] objectForKey:cachedImageIdentifier];
     if (cachedImage) {
+        self.locationShown = location;
         self.bubbleImageView.image = cachedImage;
         self.bubbleImageView.contentMode = UIViewContentModeScaleAspectFill;
         self.bubbleImageView.hidden = NO;


### PR DESCRIPTION
This fixes an issue in which, if you open the context menu on a message bubble, then pan the scroll by first tapping on the message bubble (rather in the empty area to the side of the messages), then dragging, the context menu will not close.

Additionally, cached location images were not being loaded properly, having no location data being set (this affected some additional functionality that I've been working on).