### PR TITLE
Don't call sendLocationMessage if not necessary

### DIFF
--- a/Code/Controllers/ATLConversationViewController.m
+++ b/Code/Controllers/ATLConversationViewController.m
@@ -565,7 +565,7 @@ static NSInteger const ATLPhotoActionSheet = 1000;
         return;
     }
     NSOrderedSet *messages = [self messagesForMediaAttachments:messageInputToolbar.mediaAttachments];
-    if (messages.count == 0) {
+    if (messages.count == 0 && messages) {
         [self sendLocationMessage];
     } else {
         for (LYRMessage *message in messages) {

--- a/Code/Controllers/ATLConversationViewController.m
+++ b/Code/Controllers/ATLConversationViewController.m
@@ -565,7 +565,7 @@ static NSInteger const ATLPhotoActionSheet = 1000;
         return;
     }
     NSOrderedSet *messages = [self messagesForMediaAttachments:messageInputToolbar.mediaAttachments];
-    if (messages.count == 0 && messages) {
+    if (messages.count == 0 && self.messageInputToolbar.displaysRightAccessoryImage) {
         [self sendLocationMessage];
     } else {
         for (LYRMessage *message in messages) {

--- a/Code/Controllers/ATLConversationViewController.m
+++ b/Code/Controllers/ATLConversationViewController.m
@@ -565,7 +565,7 @@ static NSInteger const ATLPhotoActionSheet = 1000;
         return;
     }
     NSOrderedSet *messages = [self messagesForMediaAttachments:messageInputToolbar.mediaAttachments];
-    if (messages.count == 0 && self.messageInputToolbar.displaysRightAccessoryImage) {
+    if (messages.count == 0 && self.messageInputToolbar.textInputView.text.length == 0) {
         [self sendLocationMessage];
     } else {
         for (LYRMessage *message in messages) {

--- a/Tests/ATLConversationViewControllerTest.m
+++ b/Tests/ATLConversationViewControllerTest.m
@@ -747,9 +747,7 @@ extern NSString *const ATLMessageInputToolbarSendButton;
 {
     [self setupConversationViewController];
     [self setRootViewController:self.viewController];
-    
-    self.viewController.messageInputToolbar.displaysRightAccessoryImage = NO;
-    
+        
     id viewControllerMock = OCMPartialMock(self.viewController);
     
     [[[viewControllerMock stub] andDo:^(NSInvocation *invocation) {

--- a/Tests/ATLConversationViewControllerTest.m
+++ b/Tests/ATLConversationViewControllerTest.m
@@ -743,6 +743,23 @@ extern NSString *const ATLMessageInputToolbarSendButton;
     }).to.raise(NSInvalidArgumentException);
 }
 
+- (void)testToVerifySendingWhitespaceDoesNotSendLocation
+{
+    [self setupConversationViewController];
+    [self setRootViewController:self.viewController];
+    
+    self.viewController.messageInputToolbar.displaysRightAccessoryImage = NO;
+    
+    id viewControllerMock = OCMPartialMock(self.viewController);
+    
+    [[[viewControllerMock stub] andDo:^(NSInvocation *invocation) {
+        failure(@"Shouldn't call send location message");
+    }] sendLocationMessage];
+    
+    [tester enterText:@" " intoViewWithAccessibilityLabel:ATLMessageInputToolbarAccessibilityLabel];
+    [tester tapViewWithAccessibilityLabel:ATLMessageInputToolbarSendButton];
+}
+
 - (void)setupConversationViewController
 {
     self.viewController = [ATLSampleConversationViewController conversationViewControllerWithLayerClient:(LYRClient *)self.testInterface.layerClient];

--- a/Tests/ATLMessageInputBarTest.m
+++ b/Tests/ATLMessageInputBarTest.m
@@ -260,6 +260,25 @@ extern NSString *const ATLMessageInputToolbarSendButton;
     [delegateMock verify];
 }
 
+- (void)testToVerifySendingWhitespaceDoesNotSendLocation
+{
+    [self setRootViewController];
+    
+    id delegateMock = OCMProtocolMock(@protocol(ATLConversationViewControllerDelegate));
+    self.viewController.delegate = delegateMock;
+    
+    [[[delegateMock expect] andReturn:[NSOrderedSet orderedSet]] conversationViewController:self.viewController messagesForMediaAttachments:[OCMArg any]];
+    
+    id viewControllerMock = OCMPartialMock(self.viewController);
+    
+    [[[viewControllerMock stub] andDo:^(NSInvocation *invocation) {
+        failure(@"Shouldn't call send location message");
+    }] sendLocationMessage];
+    
+    [tester enterText:@" " intoViewWithAccessibilityLabel:ATLMessageInputToolbarAccessibilityLabel];
+    [tester tapViewWithAccessibilityLabel:ATLMessageInputToolbarSendButton];
+}
+
 - (void)testToVerifySelectingAndRemovingAnImageKeepsFontConsistent
 {
     [self setRootViewController];

--- a/Tests/ATLMessageInputBarTest.m
+++ b/Tests/ATLMessageInputBarTest.m
@@ -260,25 +260,6 @@ extern NSString *const ATLMessageInputToolbarSendButton;
     [delegateMock verify];
 }
 
-- (void)testToVerifySendingWhitespaceDoesNotSendLocation
-{
-    [self setRootViewController];
-    
-    id delegateMock = OCMProtocolMock(@protocol(ATLConversationViewControllerDelegate));
-    self.viewController.delegate = delegateMock;
-    
-    [[[delegateMock expect] andReturn:[NSOrderedSet orderedSet]] conversationViewController:self.viewController messagesForMediaAttachments:[OCMArg any]];
-    
-    id viewControllerMock = OCMPartialMock(self.viewController);
-    
-    [[[viewControllerMock stub] andDo:^(NSInvocation *invocation) {
-        failure(@"Shouldn't call send location message");
-    }] sendLocationMessage];
-    
-    [tester enterText:@" " intoViewWithAccessibilityLabel:ATLMessageInputToolbarAccessibilityLabel];
-    [tester tapViewWithAccessibilityLabel:ATLMessageInputToolbarSendButton];
-}
-
 - (void)testToVerifySelectingAndRemovingAnImageKeepsFontConsistent
 {
     [self setRootViewController];


### PR DESCRIPTION
Functionality and tests for not calling `sendLocationMessage` which would then results in requesting permissions.