### PR TITLE
Image and gif loading now occurs on a non main thread, and then is bought back to the main thread for the image view update

### DIFF
--- a/ATLMessageCollectionViewCellTests.m
+++ b/ATLMessageCollectionViewCellTests.m
@@ -10,18 +10,13 @@
 #import <XCTest/XCTest.h>
 #import <AssetsLibrary/AssetsLibrary.h>
 #import "ATLMessageCollectionViewCell.h"
+#import "ATLTestClasses.h"
 #import "ATLTestUtilities.h"
 #define EXP_SHORTHAND
 #import <Expecta/Expecta.h>
 #import <OCMock/OCMock.h>
 #import "LYRMessageMock.h"
 #import "LYRMessagePartMock.h"
-
-@interface ATLMessageCollectionViewCell ()
-
-@property (strong, nonatomic) LYRMessage *message;
-
-@end
 
 @interface ATLMessageCollectionViewCellTests : XCTestCase
 
@@ -62,21 +57,22 @@
     LYRMessageMock *messageMock1 = [LYRMessageMock newMessageWithParts:@[ part1, part2 ] senderID:[ATLUserMock userWithMockUserName:ATLMockUserNameKlemen].participantIdentifier];
     LYRMessageMock *messageMock2 = [LYRMessageMock newMessageWithParts:@[ [LYRMessagePartMock messagePartWithMIMEType:@"text/plain" data:[@"test" dataUsingEncoding:NSUTF8StringEncoding]] ]  senderID:[ATLUserMock userWithMockUserName:ATLMockUserNameKlemen].participantIdentifier];
     
-    dispatch_semaphore_t semaphore = dispatch_semaphore_create(0);
+    dispatch_semaphore_t semaphore = dispatch_semaphore_create(2);
 
     id partialmockedPart = OCMPartialMock(part1);
-    OCMStub([partialmockedPart data]).andDo(^(NSInvocation *invocation){
-        NSLog(@"test");
+    [[partialmockedPart expect] andForwardToRealObject];
+    [[partialmockedPart expect] andForwardToRealObject];
+    [[partialmockedPart expect] andForwardToRealObject];
+    [[partialmockedPart expect] andDo:^(NSInvocation *invocation) {
         dispatch_semaphore_wait(semaphore, DISPATCH_TIME_FOREVER);
-        [invocation setReturnValue:(__bridge void *)data];
-        NSLog(@"test2");
-    });
-    
-    [cell presentMessage:messageMock1];
-    //[cell presentMessage:messageMock2];
-    
-    dispatch_semaphore_signal(semaphore);
+        [invocation setReturnValue:(__bridge void *)(data)];
+    }];
+    [cell presentMessage:(LYRMessage *)messageMock1];
+    [cell prepareForReuse];
+    [cell presentMessage:(LYRMessage *)messageMock2];
 
+    dispatch_semaphore_signal(semaphore);
+    
    [partialMock verifyWithDelay:2.0f];
 }
 

--- a/ATLMessageCollectionViewCellTests.m
+++ b/ATLMessageCollectionViewCellTests.m
@@ -1,0 +1,83 @@
+//
+//  ATLMessageCollectionViewCellTests.m
+//  Atlas
+//
+//  Created by Kabir Mahal on 8/17/15.
+//
+//
+
+#import <UIKit/UIKit.h>
+#import <XCTest/XCTest.h>
+#import <AssetsLibrary/AssetsLibrary.h>
+#import "ATLMessageCollectionViewCell.h"
+#import "ATLTestUtilities.h"
+#define EXP_SHORTHAND
+#import <Expecta/Expecta.h>
+#import <OCMock/OCMock.h>
+#import "LYRMessageMock.h"
+#import "LYRMessagePartMock.h"
+
+@interface ATLMessageCollectionViewCell ()
+
+@property (strong, nonatomic) LYRMessage *message;
+
+@end
+
+@interface ATLMessageCollectionViewCellTests : XCTestCase
+
+@end
+
+@implementation ATLMessageCollectionViewCellTests
+
+- (void)setUp {
+    [super setUp];
+    // Put setup code here. This method is called before the invocation of each test method in the class.
+}
+
+- (void)tearDown {
+    // Put teardown code here. This method is called after the invocation of each test method in the class.
+    [super tearDown];
+}
+
+
+- (void)testThatAsynchronousImageAndGifLoadingDoesNotUpdateReusedCells
+{
+    ATLMessageCollectionViewCell *cell = [[ATLMessageCollectionViewCell alloc] initWithFrame:CGRectZero];
+    ATLMessageBubbleView *bubbleView = cell.bubbleView;
+    id partialMock = OCMPartialMock(bubbleView);
+    [[[partialMock reject] ignoringNonObjectArgs] updateWithImage:[OCMArg any] width:1337];
+    
+    NSBundle *parentBundle = [NSBundle bundleForClass:[self class]];
+    NSURL *url = [parentBundle URLForResource:@"boatgif" withExtension:@"gif"];
+    NSData *data = [NSData dataWithContentsOfURL:url];
+    UIImage *gif = [UIImage imageWithData:data];
+    
+    LYRMessagePartMock *part1 = [LYRMessagePartMock messagePartWithMIMEType:ATLMIMETypeImageGIF data:data];
+    data = part1.data;
+    NSDictionary *imageMetadata = @{ @"width": @(gif.size.width),
+                                     @"height": @(gif.size.height),
+                                     @"orientation": @(gif.imageOrientation) };
+    NSData *JSONData = [NSJSONSerialization dataWithJSONObject:imageMetadata options:NSJSONWritingPrettyPrinted error:nil];
+    LYRMessagePartMock *part2 = [LYRMessagePartMock messagePartWithMIMEType:ATLMIMETypeImageSize data:JSONData];
+    LYRMessageMock *messageMock1 = [LYRMessageMock newMessageWithParts:@[ part1, part2 ] senderID:[ATLUserMock userWithMockUserName:ATLMockUserNameKlemen].participantIdentifier];
+    LYRMessageMock *messageMock2 = [LYRMessageMock newMessageWithParts:@[ [LYRMessagePartMock messagePartWithMIMEType:@"text/plain" data:[@"test" dataUsingEncoding:NSUTF8StringEncoding]] ]  senderID:[ATLUserMock userWithMockUserName:ATLMockUserNameKlemen].participantIdentifier];
+    
+    dispatch_semaphore_t semaphore = dispatch_semaphore_create(0);
+
+    id partialmockedPart = OCMPartialMock(part1);
+    OCMStub([partialmockedPart data]).andDo(^(NSInvocation *invocation){
+        NSLog(@"test");
+        dispatch_semaphore_wait(semaphore, DISPATCH_TIME_FOREVER);
+        [invocation setReturnValue:(__bridge void *)data];
+        NSLog(@"test2");
+    });
+    
+    [cell presentMessage:messageMock1];
+    //[cell presentMessage:messageMock2];
+    
+    dispatch_semaphore_signal(semaphore);
+
+   [partialMock verifyWithDelay:2.0f];
+}
+
+@end

--- a/ATLMessageCollectionViewCellTests.m
+++ b/ATLMessageCollectionViewCellTests.m
@@ -3,7 +3,19 @@
 //  Atlas
 //
 //  Created by Kabir Mahal on 8/17/15.
+//  Copyright (c) 2015 Layer. All rights reserved.
 //
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
 //
 
 #import <UIKit/UIKit.h>
@@ -33,7 +45,6 @@
     // Put teardown code here. This method is called after the invocation of each test method in the class.
     [super tearDown];
 }
-
 
 - (void)testThatAsynchronousImageAndGifLoadingDoesNotUpdateReusedCells
 {

--- a/Atlas.xcodeproj/project.pbxproj
+++ b/Atlas.xcodeproj/project.pbxproj
@@ -9,6 +9,8 @@
 /* Begin PBXBuildFile section */
 		2B6445637A4A449ABC5750C4 /* libPods-StoryboardTests.a in Frameworks */ = {isa = PBXBuildFile; fileRef = DFFB13F66B57103A728CA624 /* libPods-StoryboardTests.a */; };
 		377EEF73853F61FE5B5568A2 /* libPods-Storyboard.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 12E6C660682C89FC093228B5 /* libPods-Storyboard.a */; };
+		5AEFC5CB1B79834300ADE4EC /* boatgif.gif in Resources */ = {isa = PBXBuildFile; fileRef = 5AEFC5CA1B79834300ADE4EC /* boatgif.gif */; };
+		5AEFC5CC1B79834300ADE4EC /* boatgif.gif in Resources */ = {isa = PBXBuildFile; fileRef = 5AEFC5CA1B79834300ADE4EC /* boatgif.gif */; };
 		5AF32FD31AA59C39005C13D7 /* ATLUserMockTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 5AF32FD21AA59C39005C13D7 /* ATLUserMockTest.m */; };
 		CE7BDC080170509511B89900 /* libPods-UnitTests.a in Frameworks */ = {isa = PBXBuildFile; fileRef = F7012754989ED85BE6A8D69E /* libPods-UnitTests.a */; };
 		D0294DE71A93F37A00702856 /* Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = D0294DE61A93F37A00702856 /* Info.plist */; };
@@ -111,6 +113,7 @@
 		358D1AE37F6A67F9CE5ADC47 /* libPods-Unit Tests.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-Unit Tests.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		4A1A0BE9E193CC265341461A /* Pods-Unit Tests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Unit Tests.release.xcconfig"; path = "Pods/Target Support Files/Pods-Unit Tests/Pods-Unit Tests.release.xcconfig"; sourceTree = "<group>"; };
 		5A30E6805E705AAD798FE808 /* Pods-Programmatic.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Programmatic.release.xcconfig"; path = "Pods/Target Support Files/Pods-Programmatic/Pods-Programmatic.release.xcconfig"; sourceTree = "<group>"; };
+		5AEFC5CA1B79834300ADE4EC /* boatgif.gif */ = {isa = PBXFileReference; lastKnownFileType = image.gif; path = boatgif.gif; sourceTree = "<group>"; };
 		5AF32FD21AA59C39005C13D7 /* ATLUserMockTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ATLUserMockTest.m; sourceTree = "<group>"; };
 		5C9A8B1181386C002F1F0585 /* Pods-Conversation.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Conversation.release.xcconfig"; path = "Pods/Target Support Files/Pods-Conversation/Pods-Conversation.release.xcconfig"; sourceTree = "<group>"; };
 		6334472F1BD9D5C3E110141E /* Pods-UnitTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-UnitTests.debug.xcconfig"; path = "Pods/Target Support Files/Pods-UnitTests/Pods-UnitTests.debug.xcconfig"; sourceTree = "<group>"; };
@@ -421,6 +424,7 @@
 		D6F4060E1A8FDEEB00AE9581 /* Resources */ = {
 			isa = PBXGroup;
 			children = (
+				5AEFC5CA1B79834300ADE4EC /* boatgif.gif */,
 				D63C68DF1A94250000D235D5 /* test-logo.png */,
 				D6F4060F1A8FDEEB00AE9581 /* ProgrammaticTests-Info.plist */,
 				D6F406101A8FDEEB00AE9581 /* StoryboardTests-Info.plist */,
@@ -636,6 +640,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				5AEFC5CB1B79834300ADE4EC /* boatgif.gif in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -652,6 +657,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				D63C68E11A94250000D235D5 /* test-logo.png in Resources */,
+				5AEFC5CC1B79834300ADE4EC /* boatgif.gif in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Atlas.xcodeproj/project.pbxproj
+++ b/Atlas.xcodeproj/project.pbxproj
@@ -9,6 +9,8 @@
 /* Begin PBXBuildFile section */
 		2B6445637A4A449ABC5750C4 /* libPods-StoryboardTests.a in Frameworks */ = {isa = PBXBuildFile; fileRef = DFFB13F66B57103A728CA624 /* libPods-StoryboardTests.a */; };
 		377EEF73853F61FE5B5568A2 /* libPods-Storyboard.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 12E6C660682C89FC093228B5 /* libPods-Storyboard.a */; };
+		5A86A2D11B82BB11005AF74B /* ATLMessageCollectionViewCellTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 5A86A2D01B82BB11005AF74B /* ATLMessageCollectionViewCellTests.m */; };
+		5A86A2D21B82BB11005AF74B /* ATLMessageCollectionViewCellTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 5A86A2D01B82BB11005AF74B /* ATLMessageCollectionViewCellTests.m */; };
 		5AEFC5CB1B79834300ADE4EC /* boatgif.gif in Resources */ = {isa = PBXBuildFile; fileRef = 5AEFC5CA1B79834300ADE4EC /* boatgif.gif */; };
 		5AEFC5CC1B79834300ADE4EC /* boatgif.gif in Resources */ = {isa = PBXBuildFile; fileRef = 5AEFC5CA1B79834300ADE4EC /* boatgif.gif */; };
 		5AF32FD31AA59C39005C13D7 /* ATLUserMockTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 5AF32FD21AA59C39005C13D7 /* ATLUserMockTest.m */; };
@@ -113,6 +115,7 @@
 		358D1AE37F6A67F9CE5ADC47 /* libPods-Unit Tests.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-Unit Tests.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		4A1A0BE9E193CC265341461A /* Pods-Unit Tests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Unit Tests.release.xcconfig"; path = "Pods/Target Support Files/Pods-Unit Tests/Pods-Unit Tests.release.xcconfig"; sourceTree = "<group>"; };
 		5A30E6805E705AAD798FE808 /* Pods-Programmatic.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Programmatic.release.xcconfig"; path = "Pods/Target Support Files/Pods-Programmatic/Pods-Programmatic.release.xcconfig"; sourceTree = "<group>"; };
+		5A86A2D01B82BB11005AF74B /* ATLMessageCollectionViewCellTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ATLMessageCollectionViewCellTests.m; sourceTree = "<group>"; };
 		5AEFC5CA1B79834300ADE4EC /* boatgif.gif */ = {isa = PBXFileReference; lastKnownFileType = image.gif; path = boatgif.gif; sourceTree = "<group>"; };
 		5AF32FD21AA59C39005C13D7 /* ATLUserMockTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ATLUserMockTest.m; sourceTree = "<group>"; };
 		5C9A8B1181386C002F1F0585 /* Pods-Conversation.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Conversation.release.xcconfig"; path = "Pods/Target Support Files/Pods-Conversation/Pods-Conversation.release.xcconfig"; sourceTree = "<group>"; };
@@ -273,6 +276,7 @@
 		D0294DE31A93F36100702856 /* Unit Tests */ = {
 			isa = PBXGroup;
 			children = (
+				5A86A2D01B82BB11005AF74B /* ATLMessageCollectionViewCellTests.m */,
 				D0294DE41A93F37000702856 /* ATLMediaStreamTests.m */,
 				D04517131A9F9A0C00E137D9 /* ATLMediaAttachmentTests.m */,
 				D0294DE61A93F37A00702856 /* Info.plist */,
@@ -862,6 +866,7 @@
 				D6F4062F1A8FE28000AE9581 /* ATLMessageCollectionViewCellTest.m in Sources */,
 				D6F406301A8FE28000AE9581 /* ATLMessageInputBarTest.m in Sources */,
 				D6C0454F1A9953C70028E9D0 /* ALTAddressBarControllerTest.m in Sources */,
+				5A86A2D11B82BB11005AF74B /* ATLMessageCollectionViewCellTests.m in Sources */,
 				D6F406321A8FE28000AE9581 /* ATLParticipantTableViewControllerTest.m in Sources */,
 				D6F406331A8FE28000AE9581 /* ATLParticipantTableViewCellTest.m in Sources */,
 			);
@@ -902,6 +907,7 @@
 				D6A122BC1A9D2CA2004F67BE /* ATLConversationViewControllerTest.m in Sources */,
 				D6A122BD1A9D2CA2004F67BE /* ATLMessageInputBarTest.m in Sources */,
 				D6A122BE1A9D2CA2004F67BE /* ATLParticipantTableViewControllerTest.m in Sources */,
+				5A86A2D21B82BB11005AF74B /* ATLMessageCollectionViewCellTests.m in Sources */,
 				D6A122BF1A9D2CA2004F67BE /* ALTAddressBarControllerTest.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Code/Views/ATLMessageCollectionViewCell.m
+++ b/Code/Views/ATLMessageCollectionViewCell.m
@@ -273,12 +273,12 @@ CGFloat const ATLAvatarImageTailPadding = 7.0f;
                     [weakSelf.bubbleView updateWithImage:displayingImage width:size.width];
                 } else if (fullResImagePart.transferStatus == LYRContentTransferDownloading) {
                     LYRProgress *progress = fullResImagePart.progress;
-                    [progress setDelegate:self];
+                    [progress setDelegate:weakSelf];
                     weakSelf.progress = progress;
                     [weakSelf.bubbleView updateProgressIndicatorWithProgress:progress.fractionCompleted visible:YES animated:NO];
                     [weakSelf.bubbleView updateWithImage:displayingImage width:size.width];
                 } else {
-                    dispatch_async(self.imageProcessingConcurrentQueue, ^{
+                    dispatch_async(weakSelf.imageProcessingConcurrentQueue, ^{
                         displayingImage = ATLAnimatedImageWithAnimatedGIFData(fullResImagePart.data);
                         dispatch_async(dispatch_get_main_queue(), ^{
                             if (weakSelf.message != previousMessage) {

--- a/Tests/ATLMessageCollectionViewCellTest.m
+++ b/Tests/ATLMessageCollectionViewCellTest.m
@@ -37,8 +37,6 @@
 NSString *ATLTestMessageText = @"Test Message Text";
 
 extern NSString *const ATLConversationCollectionViewAccessibilityIdentifier;
-extern NSString *const ATLMessageInputToolbarSendButton;
-extern NSString *const ATLMIMETypeImageSize;
 
 - (void)setUp
 {

--- a/Tests/ATLMessageCollectionViewCellTest.m
+++ b/Tests/ATLMessageCollectionViewCellTest.m
@@ -203,16 +203,16 @@ extern NSString *const ATLMIMETypeImageSize;
     
     dispatch_semaphore_t semaphore = dispatch_semaphore_create(0);
 
-//    id partialmockedPart = OCMPartialMock(part1);
-//    OCMStub([partialmockedPart data]).andDo(^(NSInvocation *invocation){
-//        NSLog(@"wait %@", [NSThread callStackSymbols]);
-//        dispatch_semaphore_wait(semaphore, DISPATCH_TIME_FOREVER);
-//        [invocation setReturnValue:(__bridge void *)data];
-//        NSLog(@"second tiem");
-//    });
-//    dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_BACKGROUND, 0), ^{
-//        [self.conversation sendMessage:message error:nil];
-//    });
+    id partialmockedPart = OCMPartialMock(part1);
+    OCMStub([partialmockedPart data]).andDo(^(NSInvocation *invocation){
+        NSLog(@"wait %@", [NSThread callStackSymbols]);
+        dispatch_semaphore_wait(semaphore, DISPATCH_TIME_FOREVER);
+        [invocation setReturnValue:(__bridge void *)data];
+        NSLog(@"second tiem");
+    });
+    dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_BACKGROUND, 0), ^{
+        [self.conversation sendMessage:message error:nil];
+    });
     [self.conversation sendMessage:message error:nil];
 
     [self.controller.collectionView setContentOffset:CGPointZero];

--- a/Tests/ATLMessageCollectionViewCellTest.m
+++ b/Tests/ATLMessageCollectionViewCellTest.m
@@ -37,6 +37,8 @@
 NSString *ATLTestMessageText = @"Test Message Text";
 
 extern NSString *const ATLConversationCollectionViewAccessibilityIdentifier;
+extern NSString *const ATLMessageInputToolbarSendButton;
+extern NSString *const ATLMIMETypeImageSize;
 
 - (void)setUp
 {
@@ -179,7 +181,36 @@ extern NSString *const ATLConversationCollectionViewAccessibilityIdentifier;
     expect(phoneNumberAttributes[NSUnderlineStyleAttributeName]).to.equal(NSUnderlineStyleSingle);
 }
 
+- (void)testToVerifyAsynchronousImageAndGifLoadingDoesNotRetainCells
+{
+    for (int i = 0; i < 20; i++) {
+        LYRMessagePart *part = [LYRMessagePart messagePartWithText:@"Hey Dude"];
+        LYRMessageMock *message = [LYRMessageMock newMessageWithParts:@[part] senderID:[ATLUserMock userWithMockUserName:ATLMockUserNameKlemen].participantIdentifier];
+        [self.conversation sendMessage:message error:nil];
+    }
+    NSBundle *parentBundle = [NSBundle bundleForClass:[self class]];
+    NSURL *url = [parentBundle URLForResource:@"boatgif" withExtension:@"gif"];
+    NSData *data = [NSData dataWithContentsOfURL:url];
+    UIImage *gif = [UIImage imageWithData:data];
+    
+    LYRMessagePartMock *part1 = [LYRMessagePartMock messagePartWithMIMEType:ATLMIMETypeImageGIF data:data];
+    NSDictionary *imageMetadata = @{ @"width": @(gif.size.width),
+                                     @"height": @(gif.size.height),
+                                     @"orientation": @(gif.imageOrientation) };
+    NSData *JSONData = [NSJSONSerialization dataWithJSONObject:imageMetadata options:NSJSONWritingPrettyPrinted error:nil];
+    LYRMessagePartMock *part2 = [LYRMessagePartMock messagePartWithMIMEType:ATLMIMETypeImageSize data:JSONData];
+    LYRMessageMock *message = [LYRMessageMock newMessageWithParts:@[ part1, part2 ] senderID:[ATLUserMock userWithMockUserName:ATLMockUserNameKlemen].participantIdentifier];
+    [self.conversation sendMessage:message error:nil];
+    [self.controller.collectionView setContentOffset:CGPointZero];
+    id partialmockedPart = OCMPartialMock(part1);
+    OCMStub([partialmockedPart data]).andReturn(data);
+    
+//    id mock = OCMClassMock([ATLMessageBubbleView class]);
+//    [[mock reject] updateWithImage:[OCMArg any] width:215];
+}
+
 #pragma mark - Outgoing Customization
+
 - (void)testToVerifyOutgoingCustomMessageTextFont
 {
     UIFont *font = [UIFont systemFontOfSize:20];

--- a/Tests/ATLMessageCollectionViewCellTest.m
+++ b/Tests/ATLMessageCollectionViewCellTest.m
@@ -200,13 +200,28 @@ extern NSString *const ATLMIMETypeImageSize;
     NSData *JSONData = [NSJSONSerialization dataWithJSONObject:imageMetadata options:NSJSONWritingPrettyPrinted error:nil];
     LYRMessagePartMock *part2 = [LYRMessagePartMock messagePartWithMIMEType:ATLMIMETypeImageSize data:JSONData];
     LYRMessageMock *message = [LYRMessageMock newMessageWithParts:@[ part1, part2 ] senderID:[ATLUserMock userWithMockUserName:ATLMockUserNameKlemen].participantIdentifier];
-    [self.conversation sendMessage:message error:nil];
-    [self.controller.collectionView setContentOffset:CGPointZero];
-    id partialmockedPart = OCMPartialMock(part1);
-    OCMStub([partialmockedPart data]).andReturn(data);
     
-//    id mock = OCMClassMock([ATLMessageBubbleView class]);
-//    [[mock reject] updateWithImage:[OCMArg any] width:215];
+    dispatch_semaphore_t semaphore = dispatch_semaphore_create(0);
+
+//    id partialmockedPart = OCMPartialMock(part1);
+//    OCMStub([partialmockedPart data]).andDo(^(NSInvocation *invocation){
+//        NSLog(@"wait %@", [NSThread callStackSymbols]);
+//        dispatch_semaphore_wait(semaphore, DISPATCH_TIME_FOREVER);
+//        [invocation setReturnValue:(__bridge void *)data];
+//        NSLog(@"second tiem");
+//    });
+//    dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_BACKGROUND, 0), ^{
+//        [self.conversation sendMessage:message error:nil];
+//    });
+    [self.conversation sendMessage:message error:nil];
+
+    [self.controller.collectionView setContentOffset:CGPointZero];
+    
+    dispatch_semaphore_signal(semaphore);
+    
+    id mock = OCMClassMock([ATLMessageBubbleView class]);
+    [[[mock reject] ignoringNonObjectArgs] updateWithImage:[OCMArg any] width:1337];
+    [mock verify];
 }
 
 #pragma mark - Outgoing Customization


### PR DESCRIPTION
This PR loads images and gifs on background threads when converting `NSdata` to `UImage` format, and then is set to the imageview on the main thread.  This will ensure smoother scrolling as there is no main thread delay as the data is converted.