### PR TITLE
Fix CollectionView insets in ATLBaseConversationViewController on iOS 9

### DIFF
--- a/Code/Controllers/ATLBaseConversationViewController.m
+++ b/Code/Controllers/ATLBaseConversationViewController.m
@@ -212,17 +212,13 @@ static CGFloat const ATLMaxScrollDistanceFromBottom = 150;
 
 #pragma mark - Notification Handlers
 
-- (void)keyboardWillShow:(NSNotification *)notification
-{
-    [self configureWithKeyboardNotification:notification];
-}
-
-- (void)keyboardWillHide:(NSNotification *)notification
+- (void)keyboardWillChangeFrame:(NSNotification *)notification
 {
     if (![self.navigationController.viewControllers containsObject:self]) {
         return;
     }
     [self configureWithKeyboardNotification:notification];
+    
 }
 
 - (void)messageInputToolbarDidChangeHeight:(NSNotification *)notification
@@ -345,8 +341,7 @@ static CGFloat const ATLMaxScrollDistanceFromBottom = 150;
 - (void)atl_baseRegisterForNotifications
 {
     // Keyboard Notifications
-    [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(keyboardWillShow:) name:UIKeyboardWillShowNotification object:nil];
-    [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(keyboardWillHide:) name:UIKeyboardWillHideNotification object:nil];
+    [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(keyboardWillChangeFrame:) name:UIKeyboardWillChangeFrameNotification object:nil];
     
     // ATLMessageInputToolbar Notifications
     [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(textViewTextDidBeginEditing:) name:UITextViewTextDidBeginEditingNotification object:self.messageInputToolbar.textInputView];

--- a/Code/Controllers/ATLBaseConversationViewController.m
+++ b/Code/Controllers/ATLBaseConversationViewController.m
@@ -104,10 +104,7 @@ static CGFloat const ATLMaxScrollDistanceFromBottom = 150;
     if (self.presentedViewController) {
         [self.view becomeFirstResponder];
     }
-    if (self.addressBarController && self.firstAppearance) {
-        [self updateTopCollectionViewInset];
-    }
-    [self updateBottomCollectionViewInset];
+    
 }
 
 - (void)viewDidLayoutSubviews
@@ -119,6 +116,12 @@ static CGFloat const ATLMaxScrollDistanceFromBottom = 150;
     if (!self.presentedViewController && self.navigationController && !self.view.inputAccessoryView.superview) {
         [self.view becomeFirstResponder];
     }
+    
+    if (self.addressBarController && self.firstAppearance) {
+        [self updateTopCollectionViewInset];
+    }
+    
+    [self updateBottomCollectionViewInset];
     
     if (self.isFirstAppearance) {
         self.firstAppearance = NO;

--- a/Code/Controllers/ATLBaseConversationViewController.m
+++ b/Code/Controllers/ATLBaseConversationViewController.m
@@ -278,6 +278,12 @@ static CGFloat const ATLMaxScrollDistanceFromBottom = 150;
     [UIView setAnimationBeginsFromCurrentState:YES];
     [self updateBottomCollectionViewInset];
     [self.view layoutIfNeeded];
+    
+    //Scroll to bottom if keyboard is being shown
+    if (keyboardBeginFrame.origin.y > keyboardEndFrame.origin.y) {
+        [self scrollToBottomAnimated:YES];
+    }
+    
     [UIView commitAnimations];
 }
 


### PR DESCRIPTION
- UIKeyboardWillShow notification was not being called, replaced and consolidated both UIKeyboardWillShow and UIKeyboardWillHide with UIKeyboardWillChangeFrame.

- CollectionView inset was not being set correctly from viewWillAppear, moved inset updates to viewDidLayoutSubviews.