### PR TITLE
Safety in object changes

### DIFF
--- a/Code/Controllers/ATLConversationViewController.m
+++ b/Code/Controllers/ATLConversationViewController.m
@@ -1112,13 +1112,16 @@ static NSString *const ATLDefaultPushAlertText = @"sent you a message.";
 
 - (void)queryControllerDidChangeContent:(LYRQueryController *)queryController
 {
+    NSArray *objectChanges = [self.objectChanges copy];
+    [self.objectChanges removeAllObjects];
+    
     if (self.conversationDataSource.isExpandingPaginationWindow) {
         self.showingMoreMessagesIndicator = [self.conversationDataSource moreMessagesAvailable];
         [self reloadCollectionViewAdjustingForContentHeightChange];
         return;
     }
     
-    if (self.objectChanges.count == 0) {
+    if (objectChanges.count == 0) {
         [self configurePaginationWindow];
         [self configureMoreMessagesIndicatorVisibility];
         return;
@@ -1128,7 +1131,7 @@ static NSString *const ATLDefaultPushAlertText = @"sent you a message.";
     // Prevent scrolling if user has scrolled up into the conversation history.
     BOOL shouldScrollToBottom = [self shouldScrollToBottom];
     [self.collectionView performBatchUpdates:^{
-        for (ATLDataSourceChange *change in self.objectChanges) {
+        for (ATLDataSourceChange *change in objectChanges) {
             switch (change.type) {
                 case LYRQueryControllerChangeTypeInsert:
                     [self.collectionView insertSections:[NSIndexSet indexSetWithIndex:change.newIndex]];
@@ -1150,7 +1153,6 @@ static NSString *const ATLDefaultPushAlertText = @"sent you a message.";
                     break;
             }
         }
-        [self.objectChanges removeAllObjects];
     } completion:^(BOOL finished) {
         dispatch_resume(self.animationQueue);
     }];


### PR DESCRIPTION
Gist: Make sure `self.objectChanges removeAllObjects` gets executed an keep a local copy of the array for further operations

Rare crash but affecting 500+ users so far

```
0	
CoreFoundation 0x00000001869c2530 __exceptionPreprocess + 128
1	
libobjc.A.dylib 0x00000001979440e4 objc_exception_throw + 56
2	
CoreFoundation 0x00000001869c23f0 +[NSException raise:format:arguments:] + 112
3	
Foundation 0x000000018786dc34 -[NSAssertionHandler handleFailureInMethod:object:file:lineNumber:description:] + 108
4	
UIKit 0x000000018b3a71c4 -[UICollectionView _endItemAnimations] + 9384
5	
UIKit 0x000000018b3b1b04 -[UICollectionView performBatchUpdates:completion:] + 328
6	
Hinge 0x000000010023a370 -[ATLConversationViewController queryControllerDidChangeContent:] (ATLConversationViewController.m:1185)
7	
Hinge 0x000000010079eed8 -[LYRQueryController updateWithObjectIdentifiers:changedObjects:] (LYRQueryController.m:300)
8	
libdispatch.dylib 0x0000000197f95994 _dispatch_call_block_and_release + 20
9	
libdispatch.dylib 0x0000000197f95954 _dispatch_client_callout + 12
10	
libdispatch.dylib 0x0000000197f9a20c _dispatch_main_queue_callback_4CF + 1604
11	
CoreFoundation 0x000000018697a2ec __CFRUNLOOP_IS_SERVICING_THE_MAIN_DISPATCH_QUEUE__ + 8
12	
CoreFoundation 0x0000000186978394 __CFRunLoopRun + 1488
13	
CoreFoundation 0x00000001868a51f4 CFRunLoopRunSpecific + 392
14	
GraphicsServices 0x000000018fccf6fc GSEventRunModal + 164
15	
UIKit 0x000000018b23610c UIApplicationMain + 1484
16	
Hinge 0x000000010008184c main (main.m:20)
17	
libdyld.dylib 0x0000000197fc2a08 start + 0
```

```
Invalid update: invalid number of sections. The number of sections contained in the collection view after the update (3) must be equal to the number of sections contained in the collection view before the update (3), plus or minus the number of sections inserted or deleted (1 inserted, 0 deleted).
```