### PR TITLE
Fixes bug which could cause images to paste with wrong orientation

### DIFF
--- a/Code/Utilities/ATLMessagingUtilities.h
+++ b/Code/Utilities/ATLMessagingUtilities.h
@@ -37,6 +37,7 @@ extern NSString *const ATLMIMETypeDate;               // text/date
 extern NSUInteger const ATLDefaultThumbnailSize;      // 512px
 extern NSUInteger const ATLDefaultGIFThumbnailSize;   // 64px
 
+extern NSString *const ATLPasteboardImageKey;
 extern NSString *const ATLImagePreviewWidthKey;
 extern NSString *const ATLImagePreviewHeightKey;
 extern NSString *const ATLLocationLatitudeKey;

--- a/Code/Utilities/ATLMessagingUtilities.m
+++ b/Code/Utilities/ATLMessagingUtilities.m
@@ -37,6 +37,7 @@ NSString *const ATLMIMETypeDate = @"text/date";
 NSUInteger const ATLDefaultThumbnailSize = 512;
 NSUInteger const ATLDefaultGIFThumbnailSize = 64;
 
+NSString *const ATLPasteboardImageKey = @"image";
 NSString *const ATLImagePreviewWidthKey = @"width";
 NSString *const ATLImagePreviewHeightKey = @"height";
 NSString *const ATLLocationLatitudeKey = @"lat";

--- a/Code/Views/ATLMessageBubbleView.m
+++ b/Code/Views/ATLMessageBubbleView.m
@@ -255,7 +255,8 @@ typedef NS_ENUM(NSInteger, ATLBubbleViewContentType) {
     if (!self.bubbleViewLabel.isHidden) {
         pasteboard.string = self.bubbleViewLabel.text;
     } else {
-        pasteboard.image = self.bubbleImageView.image;
+        NSData *imageData = UIImagePNGRepresentation(self.bubbleImageView.image);
+        [pasteboard setData:imageData forPasteboardType:ATLPasteboardImageKey];
     }
 }
 

--- a/Code/Views/ATLMessageInputToolbar.m
+++ b/Code/Views/ATLMessageInputToolbar.m
@@ -173,7 +173,6 @@ static CGFloat const ATLButtonHeight = 28.0f;
                                                                                   metadata:nil
                                                                              thumbnailSize:ATLDefaultThumbnailSize];
         [self insertMediaAttachment:mediaAttachment withEndLineBreak:YES];
-
     }
 }
 

--- a/Code/Views/ATLMessageInputToolbar.m
+++ b/Code/Views/ATLMessageInputToolbar.m
@@ -166,15 +166,14 @@ static CGFloat const ATLButtonHeight = 28.0f;
 
 - (void)paste:(id)sender
 {
-    NSArray *images = [UIPasteboard generalPasteboard].images;
-    if (images.count > 0) {
-        for (UIImage *image in images) {
-            ATLMediaAttachment *mediaAttachment = [ATLMediaAttachment mediaAttachmentWithImage:image
-                                                                                      metadata:nil
-                                                                                 thumbnailSize:ATLDefaultThumbnailSize];
-            [self insertMediaAttachment:mediaAttachment withEndLineBreak:YES];
-        }
-        return;
+    NSData *imageData = [[UIPasteboard generalPasteboard] dataForPasteboardType:ATLPasteboardImageKey];
+    if (imageData) {
+        UIImage *image = [UIImage imageWithData:imageData];
+        ATLMediaAttachment *mediaAttachment = [ATLMediaAttachment mediaAttachmentWithImage:image
+                                                                                  metadata:nil
+                                                                             thumbnailSize:ATLDefaultThumbnailSize];
+        [self insertMediaAttachment:mediaAttachment withEndLineBreak:YES];
+
     }
 }
 


### PR DESCRIPTION
Issue was caused by setting a `UIPasteboard` object's image property when copying an image. The UIPasteBoard would drop the image's `imageOrientation` property when extracting upon paste. 

This is remedied by serializing the image data and using `setData:forPasteboardType:` to copy the image to the pasteboard. 