### PR TITLE
Fix Conversation View's insets in popover

### DIFF
--- a/Code/Controllers/ATLBaseConversationViewController.m
+++ b/Code/Controllers/ATLBaseConversationViewController.m
@@ -211,6 +211,9 @@ static CGFloat const ATLMaxScrollDistanceFromBottom = 150;
 
 - (void)keyboardWillShow:(NSNotification *)notification
 {
+    if ([[self navigationController] modalPresentationStyle] == UIModalPresentationPopover) {
+        return;
+    }
     [self configureWithKeyboardNotification:notification];
 }
 


### PR DESCRIPTION
When the conversation view is in a popover and the keyboard is toggled, the conversation view's insets don't need to be adjusted because the popover moves to make room for the keyboard. I'm not exactly sure if this is the right solution, but this is what we implemented, so I figured I'd share it with you and let you decide.