### PR TITLE
Feature/ATLMessageInputToolbar customizations

### DIFF
--- a/Code/Controllers/ATLBaseConversationViewController.h
+++ b/Code/Controllers/ATLBaseConversationViewController.h
@@ -68,6 +68,11 @@
  */
 @property (nonatomic) BOOL displaysAddressBar;
 
+/**
+ @abstract Initializes the input accessory view of the ATLBaseConversationViewController, which by default is an instance of ATLMessageInputToolbar. Override this method to return a subclass of ATLMessageInputToolbar.
+ */
+- (ATLMessageInputToolbar *)initializeMessageInputToolbar;
+
 ///-------------------------------------
 /// @name Managing Scrolling
 ///-------------------------------------

--- a/Code/Controllers/ATLBaseConversationViewController.m
+++ b/Code/Controllers/ATLBaseConversationViewController.m
@@ -75,7 +75,7 @@ static CGFloat const ATLMaxScrollDistanceFromBottom = 150;
     [super viewDidLoad];
     
     // Add message input tool bar
-    self.messageInputToolbar = [ATLMessageInputToolbar new];
+    self.messageInputToolbar = [self initializeMessageInputToolbar];
     // Fixes an ios9 bug that causes the background of the input accessory view to be black when being presented on screen.
     self.messageInputToolbar.translucent = NO;
     // An apparent system bug causes a view controller to not be deallocated
@@ -99,6 +99,11 @@ static CGFloat const ATLMaxScrollDistanceFromBottom = 150;
         [self configureAddressbarLayoutConstraints];
     }
     [self atl_baseRegisterForNotifications];
+}
+
+- (ATLMessageInputToolbar *)initializeMessageInputToolbar
+{
+    return [ATLMessageInputToolbar new];
 }
 
 - (void)viewWillAppear:(BOOL)animated

--- a/Code/Views/ATLMessageInputToolbar.h
+++ b/Code/Views/ATLMessageInputToolbar.h
@@ -149,7 +149,7 @@ extern NSString *const ATLMessageInputToolbarAccessibilityLabel;
   @abstract The margin on top and bottom of the textInputView.
   @default 7.0f.
   */
-@property (nonatomic) CGFloat verticalMargin;
+@property (nonatomic) CGFloat verticalMargin UI_APPEARANCE_SELECTOR;
 
 /**
  @abstract The delegate object for the view.
@@ -180,5 +180,11 @@ extern NSString *const ATLMessageInputToolbarAccessibilityLabel;
  to support UISplitViewController usage.  This property should only be set when subclassing `ATLMessageInputToolbar`.
  */
 @property (nonatomic, weak) UIViewController *containerViewController;
+
+/**
+ @abstract Configures rightAccessoryButton on setup, when textInputView value changes and when media is attached. Override this method to customize right button behavior and appearance.
+ @default Configures button with atl.messagetoolbar.send.key label if textInputView has text value or image attached, shows button with rightAccessoryImage otherwise.
+ */
+- (void)configureRightAccessoryButtonState;
 
 @end

--- a/Code/Views/ATLMessageInputToolbar.m
+++ b/Code/Views/ATLMessageInputToolbar.m
@@ -46,7 +46,6 @@ NSString *const ATLMessageInputToolbarSendButton  = @"Message Input Toolbar Send
 // Compose View Margin Constants
 static CGFloat const ATLLeftButtonHorizontalMargin = 6.0f;
 static CGFloat const ATLRightButtonHorizontalMargin = 4.0f;
-static CGFloat const ATLVerticalMargin = 7.0f;
 
 // Compose View Button Constants
 static CGFloat const ATLLeftAccessoryButtonWidth = 40.0f;
@@ -60,6 +59,7 @@ static CGFloat const ATLButtonHeight = 28.0f;
     proxy.rightAccessoryButtonActiveColor = ATLBlueColor();
     proxy.rightAccessoryButtonDisabledColor = [UIColor grayColor];
     proxy.rightAccessoryButtonFont = [UIFont boldSystemFontOfSize:17];
+    proxy.verticalMargin = 7.0f;
 }
 
 - (id)init
@@ -90,8 +90,6 @@ static CGFloat const ATLButtonHeight = 28.0f;
         self.textInputView.layer.borderWidth = 0.5;
         self.textInputView.layer.cornerRadius = 5.0f;
         [self addSubview:self.textInputView];
-        
-        self.verticalMargin = ATLVerticalMargin;
         
         self.rightAccessoryButton = [[UIButton alloc] init];
         [self.rightAccessoryButton addTarget:self action:@selector(rightAccessoryButtonTapped) forControlEvents:UIControlEventTouchUpInside];


### PR DESCRIPTION
This will allow:
- instantiate a custom ATLMessageInputToolbar in ATLBaseConversationViewController extended object
- change ATLMessageInputToolbar verticalMargin property
- implement custom right accessory behavior by overriding method "configureRightAccessoryButtonState".