### PR TITLE
Don't crash if a ATLMessageCollectionViewCell subclass doesn't set this constraint 

### DIFF
--- a/Code/Views/ATLMessageCollectionViewCell.m
+++ b/Code/Views/ATLMessageCollectionViewCell.m
@@ -413,11 +413,16 @@ CGFloat const ATLAvatarImageTailPadding = 7.0f;
     if (shouldDisplayAvatarItem) {
         if ([constraints containsObject:self.bubbleWithAvatarLeadConstraint]) return;
         [self.contentView removeConstraint:self.bubbleWithoutAvatarLeadConstraint];
-        [self.contentView addConstraint:self.bubbleWithAvatarLeadConstraint];
+        if (self.bubbleWithAvatarLeadConstraint != nil) {
+            [self.contentView addConstraint:self.bubbleWithAvatarLeadConstraint];
+        }
     } else {
         if ([constraints containsObject:self.bubbleWithoutAvatarLeadConstraint]) return;
         [self.contentView removeConstraint:self.bubbleWithAvatarLeadConstraint];
-        [self.contentView addConstraint:self.bubbleWithoutAvatarLeadConstraint];
+
+        if (self.bubbleWithoutAvatarLeadConstraint != nil) {
+            [self.contentView addConstraint:self.bubbleWithoutAvatarLeadConstraint];
+        }
     }
     [self setNeedsUpdateConstraints];
 }

--- a/Code/Views/ATLMessageCollectionViewCell.m
+++ b/Code/Views/ATLMessageCollectionViewCell.m
@@ -419,7 +419,6 @@ CGFloat const ATLAvatarImageTailPadding = 7.0f;
     } else {
         if ([constraints containsObject:self.bubbleWithoutAvatarLeadConstraint]) return;
         [self.contentView removeConstraint:self.bubbleWithAvatarLeadConstraint];
-
         if (self.bubbleWithoutAvatarLeadConstraint != nil) {
             [self.contentView addConstraint:self.bubbleWithoutAvatarLeadConstraint];
         }


### PR DESCRIPTION
I think there are times where a subclass may not define a bubbleWithAvatarLeadConstraint, in those cases I think the application should not crash.

(Reopening this as a new PR because old one was based on my master branch :/)