### PR TITLE
Added a nil safety-check to shouldDisplayAvatarItemAtIndexPath

### DIFF
--- a/Code/Controllers/ATLConversationViewController.m
+++ b/Code/Controllers/ATLConversationViewController.m
@@ -526,6 +526,10 @@ static NSInteger const ATLPhotoActionSheet = 1000;
     if (!self.shouldDisplayAvatarItem) return NO;
    
     LYRMessage *message = [self.conversationDataSource messageAtCollectionViewIndexPath:indexPath];
+    if (message.sender.userID == nil) {
+        return NO;
+    }
+    
     if ([message.sender.userID isEqualToString:self.layerClient.authenticatedUserID] && !self.shouldDisplayAvatarItemForAuthenticatedUser) {
         return NO;
     }


### PR DESCRIPTION
This prevents errors being thrown when avatar items are enabled and a
message sender has a name rather than a userID (such as when a message
is sent by a platform).