### PR TITLE
Improved long-press behaviour on ATLMessageBubbleView

### DIFF
--- a/Code/Views/ATLMessageBubbleView.m
+++ b/Code/Views/ATLMessageBubbleView.m
@@ -333,7 +333,10 @@ typedef NS_ENUM(NSInteger, ATLBubbleViewContentType) {
             menuController.arrowDirection = UIMenuControllerArrowDefault;
         }
 
+        self.panGestureRecognizer.enabled = NO;
         [menuController setMenuVisible:YES animated:YES];
+    } else if ([recognizer state] == UIGestureRecognizerStateEnded) {
+        self.panGestureRecognizer.enabled = YES;
     }
 }
 

--- a/Code/Views/ATLMessageBubbleView.m
+++ b/Code/Views/ATLMessageBubbleView.m
@@ -264,6 +264,7 @@ typedef NS_ENUM(NSInteger, ATLBubbleViewContentType) {
 {
     [self.longPressMask removeFromSuperview];
     self.longPressMask = nil;
+    [[UIMenuController sharedMenuController] setMenuItems:nil];
     [[NSNotificationCenter defaultCenter] removeObserver:self];
 }
 

--- a/Code/Views/ATLMessageBubbleView.m
+++ b/Code/Views/ATLMessageBubbleView.m
@@ -44,6 +44,7 @@ typedef NS_ENUM(NSInteger, ATLBubbleViewContentType) {
 @property (nonatomic) CLLocationCoordinate2D locationShown;
 @property (nonatomic) UITapGestureRecognizer *tapGestureRecognizer;
 @property (nonatomic) UIPanGestureRecognizer *panGestureRecognizer;
+@property (nonatomic) UILongPressGestureRecognizer *longPressGestureRecognizer;
 @property (nonatomic) NSURL *tappedURL;
 @property (nonatomic) NSString *tappedPhoneNumber;
 @property (nonatomic) NSLayoutConstraint *imageWidthConstraint;
@@ -102,8 +103,9 @@ typedef NS_ENUM(NSInteger, ATLBubbleViewContentType) {
         _panGestureRecognizer.delegate = self;
         [self addGestureRecognizer:_panGestureRecognizer];
 
-        UILongPressGestureRecognizer *gestureRecognizer = [[UILongPressGestureRecognizer alloc] initWithTarget:self action:@selector(handleLongPress:)];
-        [self addGestureRecognizer:gestureRecognizer];
+        _longPressGestureRecognizer = [[UILongPressGestureRecognizer alloc] initWithTarget:self action:@selector(handleLongPress:)];
+        _longPressGestureRecognizer.delegate = self;
+        [self addGestureRecognizer:_longPressGestureRecognizer];
         
         UIMenuItem *resetMenuItem = [[UIMenuItem alloc] initWithTitle:@"Copy" action:@selector(copyItem)];
         _menuControllerActions = @[resetMenuItem];
@@ -387,6 +389,9 @@ typedef NS_ENUM(NSInteger, ATLBubbleViewContentType) {
 - (BOOL)gestureRecognizer:(UIGestureRecognizer *)gestureRecognizer
 shouldRecognizeSimultaneouslyWithGestureRecognizer:(UIGestureRecognizer *)otherGestureRecognizer {
     if (gestureRecognizer == self.panGestureRecognizer || otherGestureRecognizer == self.panGestureRecognizer) {
+        return YES;
+    }
+    if ((gestureRecognizer == self.longPressGestureRecognizer || otherGestureRecognizer == self.longPressGestureRecognizer) && (!self.menuControllerActions || self.menuControllerActions.count == 0)) {
         return YES;
     }
     return NO;

--- a/Code/Views/ATLMessageBubbleView.m
+++ b/Code/Views/ATLMessageBubbleView.m
@@ -264,8 +264,12 @@ typedef NS_ENUM(NSInteger, ATLBubbleViewContentType) {
 
 - (void)menuControllerDisappeared
 {
-    [self.longPressMask removeFromSuperview];
-    self.longPressMask = nil;
+    [UIView animateWithDuration:0.1 animations:^{
+        self.longPressMask.alpha = 0;
+    } completion:^(BOOL finished) {
+        [self.longPressMask removeFromSuperview];
+        self.longPressMask = nil;
+    }];
     [[UIMenuController sharedMenuController] setMenuItems:nil];
     [[NSNotificationCenter defaultCenter] removeObserver:self];
 }
@@ -293,7 +297,10 @@ typedef NS_ENUM(NSInteger, ATLBubbleViewContentType) {
         self.longPressMask = [[UIView alloc] initWithFrame:CGRectMake(0, 0, self.frame.size.width, self.frame.size.height)];
         self.longPressMask.autoresizingMask = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
         self.longPressMask.backgroundColor = [UIColor blackColor];
-        self.longPressMask.alpha = 0.1;
+        self.longPressMask.alpha = 0;
+        [UIView animateWithDuration:0.1 animations:^{
+            self.longPressMask.alpha = 0.1;
+        }];
         [self addSubview:self.longPressMask];
 
         UIMenuController *menuController = [UIMenuController sharedMenuController];


### PR DESCRIPTION
This includes four changes that generally improve the experience of long-pressing on message bubbles.

1. When setting custom menu items on a ATLMessageBubbleView (via `conversationViewController:configureCell:forMessage:`), they are now properly cleared from the global UIMenuController after the long-press. This avoids the following scenario:
Message bubble with extra menu option:
![image](http://i.imgur.com/EPFlquf.png?1)
Then long-press in the text input field:
![image](http://i.imgur.com/5Q2cJSS.png?1)

2. When you long press on a message bubble, and the menu comes up, and then you try panning (without ever lifting your finger from the screen), the scroll position is now locked until you lift your finger from the screen. This replicates the Apple Messenger behaviour.

3. If the message bubble long-press menu items are set to nil or an empty array (again, using `conversationViewController:configureCell:forMessage:`), you are now not prevented from scrolling when the menu would originally have appeared.

4. Added a 100 millisecond appearance/disappearnce transition for the dark alpha mask that covers the message bubble view when long-pressed, to make it more aesthetically-pleasing and replicate the Apple Messenger behaviour.