### PR TITLE
dismiss keyboard when left button tapped

### DIFF
--- a/Code/Controllers/ATLConversationViewController.m
+++ b/Code/Controllers/ATLConversationViewController.m
@@ -554,6 +554,10 @@ static NSInteger const ATLPhotoActionSheet = 1000;
 
 - (void)messageInputToolbar:(ATLMessageInputToolbar *)messageInputToolbar didTapLeftAccessoryButton:(UIButton *)leftAccessoryButton
 {
+    if (messageInputToolbar.textInputView.isFirstResponder) {
+        [messageInputToolbar.textInputView resignFirstResponder];
+    }
+    
     UIActionSheet *actionSheet = [[UIActionSheet alloc] initWithTitle:nil
                                                              delegate:self
                                                     cancelButtonTitle:ATLLocalizedString(@"atl.conversation.toolbar.actionsheet.cancel.key", @"Cancel", nil)


### PR DESCRIPTION
fixes #978

Issue: tap left accessory button while keyboard is visible, Alertsheet appears behind keyboard.

![screenshot png](https://cloud.githubusercontent.com/assets/617728/10030521/e289914c-612c-11e5-9348-c94c15620d07.jpeg)
