### PR TITLE
Allow avatars to be shown in the ATLAddressBarViewController

### DIFF
--- a/Code/Controllers/ATLAddressBarViewController.h
+++ b/Code/Controllers/ATLAddressBarViewController.h
@@ -105,6 +105,15 @@
  */
 @property (nonatomic) ATLAddressBarView *addressBarView;
 
+///----------------------
+// @name UI Configuration
+///----------------------
+
+/**
+ @abstract Whether the view controller should show avatars in the participant list. Default is NO.
+ */
+@property (nonatomic) BOOL shouldShowParticipantAvatars;
+
 ///------------------------------------
 // @name Managing Participant Selection
 ///------------------------------------

--- a/Code/Controllers/ATLAddressBarViewController.m
+++ b/Code/Controllers/ATLAddressBarViewController.m
@@ -22,6 +22,7 @@
 #import "ATLConstants.h"
 #import "ATLAddressBarContainerView.h"
 #import "ATLMessagingUtilities.h"
+#import "ATLParticipantTableViewCell.h"
 
 @interface ATLAddressBarViewController () <UITextViewDelegate, UITableViewDataSource, UITableViewDelegate>
 
@@ -47,6 +48,7 @@ static NSString *const ATLAddressBarParticipantAttributeName = @"ATLAddressBarPa
 - (void)viewDidLoad
 {
     [super viewDidLoad];
+    self.shouldShowParticipantAvatars = NO;
     self.view.accessibilityLabel = ATLAddressBarAccessibilityLabel;
     self.view.translatesAutoresizingMaskIntoConstraints = NO;
     
@@ -63,7 +65,7 @@ static NSString *const ATLAddressBarParticipantAttributeName = @"ATLAddressBarPa
     self.tableView.delegate = self;
     self.tableView.dataSource = self;
     self.tableView.rowHeight = 56;
-    [self.tableView registerClass:[UITableViewCell class] forCellReuseIdentifier:ATLMParticpantCellIdentifier];
+    [self.tableView registerClass:[ATLParticipantTableViewCell class] forCellReuseIdentifier:ATLMParticpantCellIdentifier];
     self.tableView.keyboardDismissMode = UIScrollViewKeyboardDismissModeOnDrag;
     self.tableView.hidden = YES;
     [self.view addSubview:self.tableView];
@@ -149,11 +151,12 @@ static NSString *const ATLAddressBarParticipantAttributeName = @"ATLAddressBarPa
 
 - (UITableViewCell *)tableView:(UITableView *)tableView cellForRowAtIndexPath:(NSIndexPath *)indexPath
 {
-    UITableViewCell *cell = [tableView dequeueReusableCellWithIdentifier:ATLMParticpantCellIdentifier];
+    ATLParticipantTableViewCell *cell = [tableView dequeueReusableCellWithIdentifier:ATLMParticpantCellIdentifier];
+    cell.titleFont = ATLMediumFont(16);
+    cell.titleColor = ATLBlueColor();
+    cell.shouldBoldTitle = NO;
     id<ATLParticipant> participant = self.participants[indexPath.row];
-    cell.textLabel.text = participant.fullName;
-    cell.textLabel.font = ATLMediumFont(16);
-    cell.textLabel.textColor = ATLBlueColor();
+    [cell presentParticipant:participant withSortType:ATLParticipantPickerSortTypeFirstName shouldShowAvatarItem:self.shouldShowParticipantAvatars];
     return cell;
 }
 

--- a/Code/Views/ATLParticipantTableViewCell.h
+++ b/Code/Views/ATLParticipantTableViewCell.h
@@ -43,4 +43,9 @@
  */
 @property (nonatomic) UIColor *titleColor UI_APPEARANCE_SELECTOR;
 
+/**
+ @abstract Whether to bold part of the title label displayed in the cell, according to the sort type. Default is YES.
+ */
+@property (nonatomic) BOOL shouldBoldTitle;
+
 @end

--- a/Code/Views/ATLParticipantTableViewCell.m
+++ b/Code/Views/ATLParticipantTableViewCell.m
@@ -59,7 +59,8 @@
     // UIAppearance Defaults
     _boldTitleFont = [UIFont boldSystemFontOfSize:17];
     _titleFont = [UIFont systemFontOfSize:17];
-    _titleColor =[UIColor blackColor];
+    _titleColor = [UIColor blackColor];
+    _shouldBoldTitle = YES;
     
     self.nameLabel = [UILabel new];
     self.nameLabel.translatesAutoresizingMaskIntoConstraints = NO;
@@ -152,7 +153,7 @@
             }
             break;
     }
-    if (rangeToBold.location != NSNotFound) {
+    if (rangeToBold.location != NSNotFound && self.shouldBoldTitle) {
         [attributedString addAttributes:@{NSFontAttributeName: self.boldTitleFont} range:rangeToBold];
     }
 


### PR DESCRIPTION
@kmahal This allows avatars to be shown in the address bar view controller. However, it changes the look of the address bar view controller since I am reusing ATLParticipantTableViewCells, so I wanted to get your advice on whether or not this is the best path to go down.