### PR TITLE
add support for displaying system user name and avatar

### DIFF
--- a/Code/Controllers/ATLConversationViewController.h
+++ b/Code/Controllers/ATLConversationViewController.h
@@ -115,6 +115,14 @@ typedef NS_ENUM(NSUInteger, ATLAvatarItemDisplayFrequency) {
 - (id<ATLParticipant>)conversationViewController:(ATLConversationViewController *)conversationViewController participantForIdentifier:(NSString *)participantIdentifier;
 
 /**
+ @abstract Asks the data source for a System User object conforming to the `ATLParticipant` protocol for a given identifier
+ @param conversationViewController The `ATLConversationViewController` requesting the object.
+ @param name The systemUser Name.
+ @return An object conforming to the `ATLParticipant` protocol.
+ */
+- (id<ATLParticipant>)conversationViewController:(ATLConversationViewController *)conversationViewController systemUserForName:(NSString *)name;
+
+/**
  @abstract Asks the data source for an `NSAttributedString` representation of a given date.
  @param conversationViewController The `ATLConversationViewController` requesting the string.
  @param date The `NSDate` object to be displayed as a string.


### PR DESCRIPTION
@kmahal we make heavy use of sending automated system messages to our users. The system user's name comes as unknown user and avatar is blank. This should allow users of Atlas to set system user avatar and name. Feedback appreciated, would be happy to modify if it needed.