### PR TITLE
Mahal/conversation vc changes

### DIFF
--- a/Code/Controllers/ATLConversationViewController.h
+++ b/Code/Controllers/ATLConversationViewController.h
@@ -254,6 +254,13 @@ typedef NS_ENUM(NSUInteger, ATLAvatarItemDisplayFrequency) {
  */
 - (void)sendLocationMessage;
 
+/**
+ @abstract Sends the specified message in the current conversation and informs the delegate of success or failure.
+ @discussion This method can be used to send custom `LYRMessage` objects that are initialized outside of Atlas's default implementation.
+ @param message The Message object to send.
+ */
+- (void)sendMessage:(LYRMessage *)message;
+
 ///---------------------------
 /// @name Configuring Behavior
 ///---------------------------

--- a/Code/Controllers/ATLConversationViewController.m
+++ b/Code/Controllers/ATLConversationViewController.m
@@ -630,15 +630,7 @@ static NSInteger const ATLPhotoActionSheet = 1000;
         completePushText = [NSString stringWithFormat:@"%@: %@", senderName, pushText];
     }
     
-    LYRPushNotificationConfiguration *defaultConfiguration = [LYRPushNotificationConfiguration new];
-    defaultConfiguration.alert = completePushText;
-    defaultConfiguration.sound = ATLPushNotificationSoundName;
-    NSDictionary *options = @{ LYRMessageOptionsPushNotificationConfigurationKey: defaultConfiguration };
-    NSError *error;
-    LYRMessage *message = [self.layerClient newMessageWithParts:parts options:options error:&error];
-    if (error) {
-        return nil;
-    }
+    LYRMessage *message = ATLMessageForParts(self.layerClient, parts, completePushText, ATLPushNotificationSoundName);
     return message;
 }
 

--- a/Code/Utilities/ATLMessagingUtilities.h
+++ b/Code/Utilities/ATLMessagingUtilities.h
@@ -83,6 +83,12 @@ CGRect ATLImageRectConstrainedToSize(CGSize imageSize, CGSize maxSize);
 
 CGFloat ATLDegreeToRadians(CGFloat degrees);
 
+//------------------------
+// @name Message Utilities
+//------------------------
+
+LYRMessage *ATLMessageForParts(LYRClient *layerClient, NSArray *messageParts, NSString *pushText, NSString *pushSound);
+
 //-----------------------------
 // @name Message Part Utilities
 //-----------------------------

--- a/Code/Utilities/ATLMessagingUtilities.m
+++ b/Code/Utilities/ATLMessagingUtilities.m
@@ -151,6 +151,22 @@ CGSize  ATLSizeFromOriginalSizeWithConstraint(CGSize originalSize, CGFloat const
     return originalSize;
 }
 
+#pragma mark - Message Utilities
+
+LYRMessage *ATLMessageForParts(LYRClient *layerClient, NSArray *messageParts, NSString *pushText, NSString *pushSound)
+{
+    LYRPushNotificationConfiguration *defaultConfiguration = [LYRPushNotificationConfiguration new];
+    defaultConfiguration.alert = pushText;
+    defaultConfiguration.sound = pushSound;
+    NSDictionary *options = @{ LYRMessageOptionsPushNotificationConfigurationKey: defaultConfiguration };
+    NSError *error;
+    LYRMessage *message = [layerClient newMessageWithParts:messageParts options:options error:&error];
+    if (error) {
+        return nil;
+    }
+    return message;
+}
+
 #pragma mark - Message Parts Utilities
 
 NSArray *ATLMessagePartsWithMediaAttachment(ATLMediaAttachment *mediaAttachment)

--- a/Code/Views/ATLMessageInputToolbar.h
+++ b/Code/Views/ATLMessageInputToolbar.h
@@ -144,7 +144,7 @@ extern NSString *const ATLMessageInputToolbarAccessibilityLabel;
   @abstract The margin on top and bottom of the textInputView.
   @default 7.0f.
   */
-@property (nonatomic) NSUInteger verticalMargin;
+@property (nonatomic) CGFloat verticalMargin;
 
 /**
  @abstract The delegate object for the view.

--- a/Code/Views/ATLMessageInputToolbar.h
+++ b/Code/Views/ATLMessageInputToolbar.h
@@ -141,6 +141,12 @@ extern NSString *const ATLMessageInputToolbarAccessibilityLabel;
 @property (nonatomic) ATLMessageComposeTextView *textInputView;
 
 /**
+  @abstract The margin on top and bottom of the textInputView.
+  @default 7.0f.
+  */
+@property (nonatomic) NSUInteger verticalMargin;
+
+/**
  @abstract The delegate object for the view.
  */
 @property (nonatomic, weak) id<ATLMessageInputToolbarDelegate> inputToolBarDelegate;

--- a/Code/Views/ATLMessageInputToolbar.m
+++ b/Code/Views/ATLMessageInputToolbar.m
@@ -90,6 +90,8 @@ static CGFloat const ATLButtonHeight = 28.0f;
         self.textInputView.layer.cornerRadius = 5.0f;
         [self addSubview:self.textInputView];
         
+        self.verticalMargin = ATLVerticalMargin;
+        
         self.rightAccessoryButton = [[UIButton alloc] init];
         [self.rightAccessoryButton addTarget:self action:@selector(rightAccessoryButtonTapped) forControlEvents:UIControlEventTouchUpInside];
         [self addSubview:self.rightAccessoryButton];
@@ -141,14 +143,14 @@ static CGFloat const ATLButtonHeight = 28.0f;
     rightButtonFrame.origin.x = CGRectGetWidth(frame) - CGRectGetWidth(rightButtonFrame) - ATLRightButtonHorizontalMargin;
 
     textViewFrame.origin.x = CGRectGetMaxX(leftButtonFrame) + ATLLeftButtonHorizontalMargin;
-    textViewFrame.origin.y = ATLVerticalMargin;
+    textViewFrame.origin.y = self.verticalMargin;
     textViewFrame.size.width = CGRectGetMinX(rightButtonFrame) - CGRectGetMinX(textViewFrame) - ATLRightButtonHorizontalMargin;
 
     self.dummyTextView.attributedText = self.textInputView.attributedText;
     CGSize fittedTextViewSize = [self.dummyTextView sizeThatFits:CGSizeMake(CGRectGetWidth(textViewFrame), MAXFLOAT)];
     textViewFrame.size.height = ceil(MIN(fittedTextViewSize.height, self.textViewMaxHeight));
 
-    frame.size.height = CGRectGetHeight(textViewFrame) + ATLVerticalMargin * 2;
+    frame.size.height = CGRectGetHeight(textViewFrame) + self.verticalMargin * 2;
     frame.origin.y -= frame.size.height - CGRectGetHeight(self.frame);
  
     // Only calculate button centerY once to anchor it to bottom of bar.

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,0 +1,48 @@
+PODS:
+  - Atlas (1.0.12):
+    - LayerKit (>= 0.17.0)
+  - Expecta (1.0.3)
+  - KIF (3.3.0):
+    - KIF/Core (= 3.3.0)
+  - KIF/Core (3.3.0)
+  - KIFViewControllerActions (1.0.0):
+    - KIF (>= 2.0.0)
+  - LayerKit (0.17.0)
+  - LYRCountDownLatch (0.9.0)
+  - OCMock (3.2)
+
+DEPENDENCIES:
+  - Atlas (from `.`)
+  - Expecta
+  - KIF
+  - KIFViewControllerActions (from `https://github.com/blakewatters/KIFViewControllerActions.git`)
+  - LayerKit
+  - LYRCountDownLatch (from `https://github.com/layerhq/LYRCountDownLatch.git`)
+  - OCMock
+
+EXTERNAL SOURCES:
+  Atlas:
+    :path: "."
+  KIFViewControllerActions:
+    :git: https://github.com/blakewatters/KIFViewControllerActions.git
+  LYRCountDownLatch:
+    :git: https://github.com/layerhq/LYRCountDownLatch.git
+
+CHECKOUT OPTIONS:
+  KIFViewControllerActions:
+    :commit: fbcaaaf2a6236c6ed840ce011a44f7e3e1f7570d
+    :git: https://github.com/blakewatters/KIFViewControllerActions.git
+  LYRCountDownLatch:
+    :commit: 02119f855ad14e7fc0dae32bbbf17c735a281cfe
+    :git: https://github.com/layerhq/LYRCountDownLatch.git
+
+SPEC CHECKSUMS:
+  Atlas: 55be2063565134d21d43ba7a08c10e518f8b58c9
+  Expecta: 9d1bff6c8b0eeee73a166a2ee898892478927a15
+  KIF: 0a82046d06f3648799cac522d2d0f7934214caac
+  KIFViewControllerActions: 73085acd975ebbfc954f7895ca1aaa9faa36b3c6
+  LayerKit: 81d635966427859230deb8ede88dbc710dcac8fd
+  LYRCountDownLatch: 9b440b42a19ddbf4e75bdd4b43726baa1527606a
+  OCMock: 28def049ef47f996b515a8eeea958be7ccab2dbb
+
+COCOAPODS: 0.39.0


### PR DESCRIPTION
This PR does:
1. Makes `sendMessage` public on `ATLConversationViewController` to allow custom `LYRMessage` objects to flow through Atlas's delegate handling.
2. Adds `verticalMargin` property on `ATLMessageInputToolbar` to allow textview margin customization.