### PR TITLE
Added ATLMessageInputToolbar right button title property

### DIFF
--- a/Code/Views/ATLMessageInputToolbar.h
+++ b/Code/Views/ATLMessageInputToolbar.h
@@ -97,9 +97,14 @@ extern NSString *const ATLMessageInputToolbarAccessibilityLabel;
  
 /**
  @abstract The right accessory button for the view.
- @discussion By default, the button displays the text "SEND".
  */
 @property (nonatomic) UIButton *rightAccessoryButton;
+
+/**
+ @abstract The right accessory button title.
+ @discussion By default, the title is "Send".
+ */
+@property (nonatomic) NSString *rightAccessoryButtonTitle;
 
 /**
  @abstract The font color for the right accessory button in active state.

--- a/Code/Views/ATLMessageInputToolbar.m
+++ b/Code/Views/ATLMessageInputToolbar.m
@@ -50,7 +50,8 @@ static CGFloat const ATLVerticalMargin = 7.0f;
 
 // Compose View Button Constants
 static CGFloat const ATLLeftAccessoryButtonWidth = 40.0f;
-static CGFloat const ATLRightAccessoryButtonWidth = 46.0f;
+static CGFloat const ATLRightAccessoryButtonDefaultWidth = 46.0f;
+static CGFloat const ATLRightAccessoryButtonPadding = 5.3f;
 static CGFloat const ATLButtonHeight = 28.0f;
 
 + (void)initialize
@@ -94,6 +95,7 @@ static CGFloat const ATLButtonHeight = 28.0f;
         
         self.rightAccessoryButton = [[UIButton alloc] init];
         [self.rightAccessoryButton addTarget:self action:@selector(rightAccessoryButtonTapped) forControlEvents:UIControlEventTouchUpInside];
+        self.rightAccessoryButtonTitle = @"Send";
         [self addSubview:self.rightAccessoryButton];
         [self configureRightAccessoryButtonState];
         
@@ -138,7 +140,11 @@ static CGFloat const ATLButtonHeight = 28.0f;
     leftButtonFrame.size.height = ATLButtonHeight;
     leftButtonFrame.origin.x = ATLLeftButtonHorizontalMargin;
 
-    rightButtonFrame.size.width = ATLRightAccessoryButtonWidth;
+    if (self.rightAccessoryButtonFont && self.textInputView.text.length) {
+        rightButtonFrame.size.width = [ATLLocalizedString(@"atl.messagetoolbar.send.key", self.rightAccessoryButtonTitle, nil) boundingRectWithSize:CGSizeMake(MAXFLOAT, MAXFLOAT) options:0 attributes:@{NSFontAttributeName: self.rightAccessoryButtonFont} context:nil].size.width + ATLRightAccessoryButtonPadding;
+    } else {
+        rightButtonFrame.size.width = ATLRightAccessoryButtonDefaultWidth;
+    }
     rightButtonFrame.size.height = ATLButtonHeight;
     rightButtonFrame.origin.x = CGRectGetWidth(frame) - CGRectGetWidth(rightButtonFrame) - ATLRightButtonHorizontalMargin;
 
@@ -385,7 +391,7 @@ static CGFloat const ATLButtonHeight = 28.0f;
     [self.rightAccessoryButton setImage:nil forState:UIControlStateNormal];
     self.rightAccessoryButton.contentEdgeInsets = UIEdgeInsetsMake(2, 0, 0, 0);
     self.rightAccessoryButton.titleLabel.font = self.rightAccessoryButtonFont;
-    [self.rightAccessoryButton setTitle:ATLLocalizedString(@"atl.messagetoolbar.send.key", @"Send", nil) forState:UIControlStateNormal];
+    [self.rightAccessoryButton setTitle:ATLLocalizedString(@"atl.messagetoolbar.send.key", self.rightAccessoryButtonTitle, nil) forState:UIControlStateNormal];
     [self.rightAccessoryButton setTitleColor:self.rightAccessoryButtonActiveColor forState:UIControlStateNormal];
     [self.rightAccessoryButton setTitleColor:self.rightAccessoryButtonDisabledColor forState:UIControlStateDisabled];
     if (!self.displaysRightAccessoryImage && !self.textInputView.text.length) {

--- a/Tests/ATLMessageInputBarTest.m
+++ b/Tests/ATLMessageInputBarTest.m
@@ -48,6 +48,8 @@ extern NSString *const ATLMessageInputToolbarAccessibilityLabel;
 extern NSString *const ATLMessageInputToolbarCameraButton;
 extern NSString *const ATLMessageInputToolbarLocationButton;
 extern NSString *const ATLMessageInputToolbarSendButton;
+CGFloat const ATLRightAccessoryButtonDefaultWidth = 46.0f;
+CGFloat const ATLRightAccessoryButtonPadding = 5.3f;
 
 - (void)setUp
 {
@@ -91,6 +93,18 @@ extern NSString *const ATLMessageInputToolbarSendButton;
     [tester clearTextFromViewWithAccessibilityLabel:ATLMessageInputToolbarTextInputView];
     [tester waitForViewWithAccessibilityLabel:ATLMessageInputToolbarLocationButton];
     [tester waitForAbsenceOfViewWithAccessibilityLabel:ATLMessageInputToolbarSendButton];
+}
+
+- (void)testToVerifyRightAccessoryButtonWidthChangesWithTitle
+{
+    [self setRootViewController];
+    ATLMessageInputToolbar *toolBar = (ATLMessageInputToolbar *)[tester waitForViewWithAccessibilityLabel:ATLMessageInputToolbarAccessibilityLabel];
+    toolBar.rightAccessoryButtonTitle = @"longer title";
+    expect(toolBar.rightAccessoryButton.frame.size.width).to.equal(ATLRightAccessoryButtonDefaultWidth);
+    toolBar.textInputView.text = @"heyhey";
+    [toolBar layoutSubviews];
+    CGFloat width = [toolBar.rightAccessoryButtonTitle boundingRectWithSize:CGSizeMake(MAXFLOAT, MAXFLOAT) options:0 attributes:@{NSFontAttributeName: toolBar.rightAccessoryButtonFont} context:nil].size.width + ATLRightAccessoryButtonPadding;
+    expect(toolBar.rightAccessoryButton.frame.size.width).to.equal(width);
 }
 
 - (void)testToVerifyRightAccessoryButtonDelegateFunctionality


### PR DESCRIPTION
Makes the right accessory button title configurable, and resizes the textinput view according to the new text.