### PR TITLE
Make ATLConversationView public

### DIFF
--- a/Code/Controllers/ATLAddressBarViewController.h
+++ b/Code/Controllers/ATLAddressBarViewController.h
@@ -82,6 +82,13 @@
  */
 - (void)addressBarViewController:(ATLAddressBarViewController *)addressBarViewController searchForParticipantsMatchingText:(NSString *)searchText completion:(void (^)(NSArray *participants))completion;
 
+/**
+ @abstract Asks the data source whether the avatar should be shown in the address bar's table view. If not overrided, will default to NO.
+ @param addressBarViewController The `ATLAddressBarViewController` to configure.
+ @discussion Can be used to show avatars in the participant list.
+ */
+- (BOOL)addressBarViewControllerShouldShowAvatar:(ATLAddressBarViewController *)addressBarViewController;
+
 @end
 
 /**

--- a/Code/Controllers/ATLAddressBarViewController.m
+++ b/Code/Controllers/ATLAddressBarViewController.m
@@ -22,6 +22,7 @@
 #import "ATLConstants.h"
 #import "ATLAddressBarContainerView.h"
 #import "ATLMessagingUtilities.h"
+#import "ATLParticipantTableViewCell.h"
 
 @interface ATLAddressBarViewController () <UITextViewDelegate, UITableViewDataSource, UITableViewDelegate>
 
@@ -63,7 +64,7 @@ static NSString *const ATLAddressBarParticipantAttributeName = @"ATLAddressBarPa
     self.tableView.delegate = self;
     self.tableView.dataSource = self;
     self.tableView.rowHeight = 56;
-    [self.tableView registerClass:[UITableViewCell class] forCellReuseIdentifier:ATLMParticpantCellIdentifier];
+    [self.tableView registerClass:[ATLParticipantTableViewCell class] forCellReuseIdentifier:ATLMParticpantCellIdentifier];
     self.tableView.keyboardDismissMode = UIScrollViewKeyboardDismissModeOnDrag;
     self.tableView.hidden = YES;
     [self.view addSubview:self.tableView];
@@ -149,11 +150,13 @@ static NSString *const ATLAddressBarParticipantAttributeName = @"ATLAddressBarPa
 
 - (UITableViewCell *)tableView:(UITableView *)tableView cellForRowAtIndexPath:(NSIndexPath *)indexPath
 {
-    UITableViewCell *cell = [tableView dequeueReusableCellWithIdentifier:ATLMParticpantCellIdentifier];
+    ATLParticipantTableViewCell *cell = [tableView dequeueReusableCellWithIdentifier:ATLMParticpantCellIdentifier];
     id<ATLParticipant> participant = self.participants[indexPath.row];
-    cell.textLabel.text = participant.fullName;
-    cell.textLabel.font = ATLMediumFont(16);
-    cell.textLabel.textColor = ATLBlueColor();
+    BOOL shouldShowAvatar = NO;
+    if ([self.delegate respondsToSelector:@selector(addressBarViewControllerShouldShowAvatar:)]) {
+        shouldShowAvatar = [self.delegate addressBarViewControllerShouldShowAvatar:self];
+    }
+    [cell presentParticipant:participant withSortType:ATLParticipantPickerSortTypeFirstName shouldShowAvatarItem:shouldShowAvatar];
     return cell;
 }
 

--- a/Code/Controllers/ATLBaseConversationViewController.h
+++ b/Code/Controllers/ATLBaseConversationViewController.h
@@ -20,6 +20,7 @@
 
 #import <UIKit/UIKit.h>
 #import "ATLAddressBarViewController.h"
+#import "ATLConversationView.h"
 #import "ATLMessageInputToolbar.h"
 #import "ATLTypingIndicatorViewController.h"
 
@@ -32,6 +33,11 @@
 ///---------------------------------------------------------------
 /// @name Accessing User Interface Components
 ///---------------------------------------------------------------
+
+/**
+@abstract The `ATLConversationView` displayed.
+*/
+@property (nonatomic) ATLConversationView *view;
 
 /**
  @abstract The `ATLAddressBarViewController` displayed for addressing new conversations or displaying names of current conversation participants.

--- a/Code/Controllers/ATLBaseConversationViewController.m
+++ b/Code/Controllers/ATLBaseConversationViewController.m
@@ -25,7 +25,6 @@
 
 @interface ATLBaseConversationViewController ()
 
-@property (nonatomic) ATLConversationView *view;
 @property (nonatomic) NSMutableArray *typingParticipantIDs;
 @property (nonatomic) NSLayoutConstraint *typingIndicatorViewBottomConstraint;
 @property (nonatomic) CGFloat keyboardHeight;

--- a/Code/Views/ATLMessageBubbleView.m
+++ b/Code/Views/ATLMessageBubbleView.m
@@ -99,6 +99,7 @@ typedef NS_ENUM(NSInteger, ATLBubbleViewContentType) {
         _progressView = [[ATLProgressView alloc] initWithFrame:CGRectMake(0, 0, 128.0f, 128.0f)];
         _progressView.translatesAutoresizingMaskIntoConstraints = NO;
         _progressView.alpha = 1.0f;
+        _progressView.hidden = YES;
         [self addSubview:_progressView];
         
         [self configureBubbleViewLabelConstraints];


### PR DESCRIPTION
I need to this to be public so I can override the message input toolbar; is this a reasonable change?