### PR TITLE
Make ATLConversationView a public property

### DIFF
--- a/Code/Controllers/ATLBaseConversationViewController.h
+++ b/Code/Controllers/ATLBaseConversationViewController.h
@@ -20,6 +20,7 @@
 
 #import <UIKit/UIKit.h>
 #import "ATLAddressBarViewController.h"
+#import "ATLConversationView.h"
 #import "ATLMessageInputToolbar.h"
 #import "ATLTypingIndicatorViewController.h"
 
@@ -32,6 +33,11 @@
 ///---------------------------------------------------------------
 /// @name Accessing User Interface Components
 ///---------------------------------------------------------------
+
+/**
+@abstract The `ATLConversationView` displayed.
+*/
+@property (nonatomic) ATLConversationView *view;
 
 /**
  @abstract The `ATLAddressBarViewController` displayed for addressing new conversations or displaying names of current conversation participants.

--- a/Code/Controllers/ATLBaseConversationViewController.m
+++ b/Code/Controllers/ATLBaseConversationViewController.m
@@ -25,7 +25,6 @@
 
 @interface ATLBaseConversationViewController ()
 
-@property (nonatomic) ATLConversationView *view;
 @property (nonatomic) NSMutableArray *typingParticipantIDs;
 @property (nonatomic) NSLayoutConstraint *typingIndicatorViewBottomConstraint;
 @property (nonatomic) CGFloat keyboardHeight;

--- a/Code/Controllers/ATLConversationViewController.h
+++ b/Code/Controllers/ATLConversationViewController.h
@@ -181,7 +181,7 @@ typedef NS_ENUM(NSUInteger, ATLAvatarItemDisplayFrequency) {
  a Layer conversation and the ability to send messages. The controller's design and functionality closely correlates with
  the conversation view controller in Messages.
 */
-@interface ATLConversationViewController : ATLBaseConversationViewController <ATLAddressBarViewControllerDelegate, UIImagePickerControllerDelegate, UINavigationControllerDelegate, LYRQueryControllerDelegate>
+@interface ATLConversationViewController : ATLBaseConversationViewController <ATLAddressBarViewControllerDelegate, ATLMessageInputToolbarDelegate, UIImagePickerControllerDelegate, UINavigationControllerDelegate, LYRQueryControllerDelegate>
 
 ///---------------------------------------
 /// @name Initializing a Controller

--- a/Code/Controllers/ATLConversationViewController.m
+++ b/Code/Controllers/ATLConversationViewController.m
@@ -32,7 +32,7 @@
 #import "ATLLocationManager.h"
 @import AVFoundation;
 
-@interface ATLConversationViewController () <UICollectionViewDataSource, UICollectionViewDelegate, ATLMessageInputToolbarDelegate, UIActionSheetDelegate, CLLocationManagerDelegate>
+@interface ATLConversationViewController () <UICollectionViewDataSource, UICollectionViewDelegate, UIActionSheetDelegate, CLLocationManagerDelegate>
 
 @property (nonatomic) ATLConversationDataSource *conversationDataSource;
 @property (nonatomic, readwrite) LYRQueryController *queryController;


### PR DESCRIPTION
I need this to be public so I can override MessageInputToolbar. Does this change seem reasonable?