### PR TITLE
ATLMessageInputToolbar call convertRect:toView: from superview

### DIFF
--- a/Code/Views/ATLMessageInputToolbar.m
+++ b/Code/Views/ATLMessageInputToolbar.m
@@ -132,7 +132,7 @@ static CGFloat const ATLButtonHeight = 28.0f;
     
     // This makes the input accessory view work with UISplitViewController to manage the frame width.
     if (self.containerViewController) {
-        CGRect windowRect = [self.containerViewController.view convertRect:self.containerViewController.view.frame toView:nil];
+        CGRect windowRect = [self.containerViewController.view.superview convertRect:self.containerViewController.view.frame toView:nil];
         frame.size.width = windowRect.size.width;
         frame.origin.x = windowRect.origin.x;
     }


### PR DESCRIPTION
This error is not immediately obvious since the superview's frame.origin.x is the same as the containerViewController view's frame.origin.x. But this calculation should be done relative to the superview, since this is the coordinate system the containerViewController's frame is relative to.