### PR TITLE
ATLConversationListViewController queryController property accessible to subclass

### DIFF
--- a/Code/Controllers/ATLConversationListViewController.h
+++ b/Code/Controllers/ATLConversationListViewController.h
@@ -272,8 +272,7 @@
 ///------------------
 
 /**
- @abstract The `LYRQueryController` which contains the results currently being displayed.
- @discussion This may be the results of a search if search is currently active. It is the data source for the table view controller. May be used to access conversations by their location in the table view.
+ @abstract The `LYRQueryController` object managing data displayed in the controller.
  */
 @property (nonatomic, readonly) LYRQueryController *queryController;
 

--- a/Code/Controllers/ATLConversationListViewController.h
+++ b/Code/Controllers/ATLConversationListViewController.h
@@ -267,10 +267,6 @@
  */
 - (void)reloadCellForConversation:(LYRConversation *)conversation;
 
-///------------------
-/// @name Subclassing
-///------------------
-
 /**
  @abstract The `LYRQueryController` object managing data displayed in the controller.
  */

--- a/Code/Controllers/ATLConversationListViewController.h
+++ b/Code/Controllers/ATLConversationListViewController.h
@@ -267,4 +267,14 @@
  */
 - (void)reloadCellForConversation:(LYRConversation *)conversation;
 
+///------------------
+/// @name Subclassing
+///------------------
+
+/**
+ @abstract The `LYRQueryController` which contains the results currently being displayed.
+ @discussion This may be the results of a search if search is currently active. It is the data source for the table view controller. May be used to access conversations by their location in the table view.
+ */
+@property (nonatomic, readonly) LYRQueryController *queryController;
+
 @end

--- a/Code/Controllers/ATLConversationListViewController.h
+++ b/Code/Controllers/ATLConversationListViewController.h
@@ -181,6 +181,11 @@
 @property (nonatomic) LYRClient *layerClient;
 
 /**
+ @abstract The `LYRQueryController` object managing data displayed in the controller.
+ */
+@property (nonatomic, readonly) LYRQueryController *queryController;
+
+/**
  @abstract The object that is informed when specific events occur
  within the `LYRConversationListViewController`.
  */
@@ -266,10 +271,5 @@
  @param conversation The Conversation object to reload the corresponding cell of. Cannot be `nil`.
  */
 - (void)reloadCellForConversation:(LYRConversation *)conversation;
-
-/**
- @abstract The `LYRQueryController` object managing data displayed in the controller.
- */
-@property (nonatomic, readonly) LYRQueryController *queryController;
 
 @end


### PR DESCRIPTION
The ATLConversationListViewController queryController property is needed to get a conversation at a specific index in the table view, such as the currently selected table view cell's index. In order to get this conversation in subclassed implementations of ATLConversationListViewController, the property needs readonly access in the header.