### PR TITLE
Fixing query controller execution issue

### DIFF
--- a/Code/Controllers/ATLConversationListViewController.m
+++ b/Code/Controllers/ATLConversationListViewController.m
@@ -86,6 +86,7 @@ NSString *const ATLConversationListViewControllerDeletionModeEveryone = @"Everyo
     _allowsEditing = YES;
     _rowHeight = 76.0f;
     _shouldDisplaySearchController = YES;
+    _hasAppeared = NO;
 }
 
 - (id)init
@@ -107,10 +108,6 @@ NSString *const ATLConversationListViewControllerDeletionModeEveryone = @"Everyo
 - (void)viewDidLoad
 {
     [super viewDidLoad];
-    
-    if (!self.queryController) {
-        [self setupConversationDataSource];
-    }
     
     self.title = ATLLocalizedString(@"atl.conversationlist.title.key", ATLConversationListViewControllerTitle, nil);
     self.accessibilityLabel = ATLConversationListViewControllerTitle;
@@ -149,6 +146,10 @@ NSString *const ATLConversationListViewControllerDeletionModeEveryone = @"Everyo
         self.tableView.rowHeight = self.rowHeight;
         [self.tableView registerClass:self.cellClass forCellReuseIdentifier:ATLConversationCellReuseIdentifier];
         if (self.allowsEditing) [self addEditButton];
+    }
+    
+    if (!self.queryController) {
+        [self setupConversationDataSource];
     }
    
     NSIndexPath *selectedIndexPath = [self.tableView indexPathForSelectedRow];
@@ -310,6 +311,9 @@ NSString *const ATLConversationListViewControllerDeletionModeEveryone = @"Everyo
 {
     if (!conversation) {
         @throw [NSException exceptionWithName:NSInvalidArgumentException reason:@"`conversation` cannot be nil." userInfo:nil];
+    }
+    if (!self.queryController) {
+        return;
     }
     NSIndexPath *indexPath = [self.queryController indexPathForObject:conversation];
     if (indexPath) {

--- a/Tests/ATLConversationListViewControllerTest.m
+++ b/Tests/ATLConversationListViewControllerTest.m
@@ -120,7 +120,7 @@ extern NSString *const ATLAvatarImageViewAccessibilityLabel;
     ATLUserMock *mockUser1 = [ATLUserMock userWithMockUserName:ATLMockUserNameKlemen];
     LYRConversationMock *conversation1 = [self newConversationWithMockUser:mockUser1 lastMessageText:@"Test Message"];
     [tester swipeViewWithAccessibilityLabel:[self.testInterface conversationLabelForConversation:conversation1] inDirection:KIFSwipeDirectionLeft];
-    [self deleteConversation:conversation1 deletionMode:LYRDeletionModeLocal];
+    [self deleteConversation:conversation1 deletionMode:LYRDeletionModeMyDevices];
 }
 
 //Test editing mode and deleting several conversations at once. Verify that all conversations selected are deleted from the table and from the Layer client.
@@ -141,13 +141,13 @@ extern NSString *const ATLAvatarImageViewAccessibilityLabel;
     [tester tapViewWithAccessibilityLabel:@"Edit"];
     
     [tester tapViewWithAccessibilityLabel:[NSString stringWithFormat:@"Delete %@", mockUser1.fullName]];
-    [self deleteConversation:conversation1 deletionMode:LYRDeletionModeLocal];
+    [self deleteConversation:conversation1 deletionMode:LYRDeletionModeMyDevices];
     
     [tester tapViewWithAccessibilityLabel:[NSString stringWithFormat:@"Delete %@", mockUser2.fullName]];
-    [self deleteConversation:conversation2 deletionMode:LYRDeletionModeLocal];
+    [self deleteConversation:conversation2 deletionMode:LYRDeletionModeMyDevices];
     
     [tester tapViewWithAccessibilityLabel:[NSString stringWithFormat:@"Delete %@", mockUser3.fullName]];
-    [self deleteConversation:conversation3 deletionMode:LYRDeletionModeLocal];
+    [self deleteConversation:conversation3 deletionMode:LYRDeletionModeMyDevices];
     
     LYRQuery *query = [LYRQuery queryWithQueryableClass:[LYRConversation class]];
     NSError *error;
@@ -391,7 +391,7 @@ extern NSString *const ATLAvatarImageViewAccessibilityLabel;
     ATLUserMock *mockUser1 = [ATLUserMock userWithMockUserName:ATLMockUserNameKlemen];
     LYRConversationMock *conversation1 = [self newConversationWithMockUser:mockUser1 lastMessageText:@"Test Message"];
     
-    LYRDeletionMode deletionMode = LYRDeletionModeLocal;
+    LYRDeletionMode deletionMode = LYRDeletionModeMyDevices;
     [[[delegateMock expect] andDo:^(NSInvocation *invocation) {
         ATLConversationListViewController *controller;
         [invocation getArgument:&controller atIndex:2];
@@ -556,7 +556,7 @@ extern NSString *const ATLAvatarImageViewAccessibilityLabel;
             [tester tapViewWithAccessibilityLabel:[NSString stringWithFormat:@"Global"]];
             [tester waitForAbsenceOfViewWithAccessibilityLabel:[self.testInterface conversationLabelForConversation:conversation]];
             break;
-        case LYRDeletionModeLocal:
+        case LYRDeletionModeMyDevices:
             [tester waitForViewWithAccessibilityLabel:@"Local"];
             [tester tapViewWithAccessibilityLabel:[NSString stringWithFormat:@"Local"]];
             [tester waitForAbsenceOfViewWithAccessibilityLabel:[self.testInterface conversationLabelForConversation:conversation]];


### PR DESCRIPTION
This PR fixes an issue with the tableview dequeueing a cell that hasn't been registered.