### PR TITLE
Fixed bug which caused text message part data to be nil when checked on message did send delegate

### DIFF
--- a/Code/Utilities/ATLMessagingUtilities.m
+++ b/Code/Utilities/ATLMessagingUtilities.m
@@ -176,6 +176,10 @@ NSArray *ATLMessagePartsWithMediaAttachment(ATLMediaAttachment *mediaAttachment)
         @throw [NSException exceptionWithName:NSInternalInconsistencyException reason:@"Cannot create an LYRMessagePart with `nil` mediaInputStream." userInfo:nil];
     }
     
+    if ([mediaAttachment.mediaMIMEType isEqualToString:ATLMIMETypeTextPlain]) {
+        return @[[LYRMessagePart messagePartWithText:mediaAttachment.textRepresentation]];
+    }
+    
     // Create the message part for the main media (should be on index zero).
     [messageParts addObject:[LYRMessagePart messagePartWithMIMEType:mediaAttachment.mediaMIMEType stream:mediaAttachment.mediaInputStream]];
     

--- a/Tests/ATLConversationViewControllerTest.m
+++ b/Tests/ATLConversationViewControllerTest.m
@@ -248,7 +248,32 @@ extern NSString *const ATLMessageInputToolbarSendButton;
         expect(message).to.beKindOf([LYRMessageMock class]);
     }] conversationViewController:[OCMArg any] didSendMessage:[OCMArg any]];
     
-    [tester enterText:@"test" intoViewWithAccessibilityLabel:ATLMessageInputToolbarTextInputView];
+    [tester enterText:@"Test" intoViewWithAccessibilityLabel:ATLMessageInputToolbarTextInputView];
+    [tester tapViewWithAccessibilityLabel:ATLMessageInputToolbarSendButton];
+    [delegateMock verify];
+}
+
+- (void)testToVerifyTextMessagePartDataIsHydratedAfterMessageSend
+{
+    [self setupConversationViewController];
+    [self setRootViewController:self.viewController];
+    
+    id delegateMock = OCMProtocolMock(@protocol(ATLConversationViewControllerDelegate));
+    self.viewController.delegate = delegateMock;
+    
+    [[[delegateMock expect] andDo:^(NSInvocation *invocation) {
+        ATLConversationViewController *controller;
+        [invocation getArgument:&controller atIndex:2];
+        expect(controller).to.equal(self.viewController);
+        
+        LYRMessage *message;
+        [invocation getArgument:&message atIndex:3];
+        expect(message).to.beKindOf([LYRMessageMock class]);
+        LYRMessagePart *messagePart = message.parts[0];
+        expect(messagePart.data).toNot.beNil();
+    }] conversationViewController:[OCMArg any] didSendMessage:[OCMArg any]];
+    
+    [tester enterText:@"Test" intoViewWithAccessibilityLabel:ATLMessageInputToolbarTextInputView];
     [tester tapViewWithAccessibilityLabel:ATLMessageInputToolbarSendButton];
     [delegateMock verify];
 }


### PR DESCRIPTION
This PR fixes an issue where `[messagePart data]` returned `nil` for text message parts.  The default `ATLMessagePartsForMediaAttachments` function uses `inputStream` values which internally return `nil` initially.