### PR TITLE
Removing isExpandingPaginationWindow bool from datasource

### DIFF
--- a/Code/Controllers/ATLConversationViewController.m
+++ b/Code/Controllers/ATLConversationViewController.m
@@ -50,6 +50,7 @@
 @property (nonatomic) BOOL shouldShareLocation;
 @property (nonatomic) BOOL canDisableAddressBar;
 @property (nonatomic) dispatch_queue_t animationQueue;
+@property (nonatomic) BOOL expandingPaginationWindow;
 
 @end
 
@@ -904,6 +905,7 @@ static NSInteger const ATLPhotoActionSheet = 1000;
     BOOL nearTop = distanceFromTop <= minimumDistanceFromTopToTriggerLoadingMore;
     if (!nearTop) return;
     
+    self.expandingPaginationWindow = YES;
     [self.conversationDataSource expandPaginationWindow];
 }
 
@@ -1173,7 +1175,7 @@ static NSInteger const ATLPhotoActionSheet = 1000;
           forChangeType:(LYRQueryControllerChangeType)type
            newIndexPath:(NSIndexPath *)newIndexPath
 {
-    if (self.conversationDataSource.isExpandingPaginationWindow) return;
+    if (self.expandingPaginationWindow) return;
     NSInteger currentIndex = indexPath ? [self.conversationDataSource collectionViewSectionForQueryControllerRow:indexPath.row] : NSNotFound;
     NSInteger newIndex = newIndexPath ? [self.conversationDataSource collectionViewSectionForQueryControllerRow:newIndexPath.row] : NSNotFound;
     [self.objectChanges addObject:[ATLDataSourceChange changeObjectWithType:type newIndex:newIndex currentIndex:currentIndex]];
@@ -1189,7 +1191,8 @@ static NSInteger const ATLPhotoActionSheet = 1000;
     NSArray *objectChanges = [self.objectChanges copy];
     [self.objectChanges removeAllObjects];
     
-    if (self.conversationDataSource.isExpandingPaginationWindow) {
+    if (self.expandingPaginationWindow) {
+        self.expandingPaginationWindow = NO;
         self.showingMoreMessagesIndicator = [self.conversationDataSource moreMessagesAvailable];
         [self reloadCollectionViewAdjustingForContentHeightChange];
         return;

--- a/Code/Models/ATLConversationDataSource.h
+++ b/Code/Models/ATLConversationDataSource.h
@@ -68,11 +68,6 @@ extern NSInteger const ATLNumberOfSectionsBeforeFirstMessageSection;
  */
 - (void)expandPaginationWindow;
 
-/**
- @abstract Returns `YES` if the data source is currently in the process of expanding its pagination window.
- */
-@property (nonatomic, readonly, getter=isExpandingPaginationWindow) BOOL expandingPaginationWindow;
-
 ///---------------------------------------
 /// @name Index Translation Methods
 ///---------------------------------------

--- a/Code/Models/ATLConversationDataSource.m
+++ b/Code/Models/ATLConversationDataSource.m
@@ -60,21 +60,17 @@ NSInteger const ATLQueryControllerPaginationWindow = 30;
 
 - (void)expandPaginationWindow
 {
-    self.expandingPaginationWindow = YES;
     if (!self.queryController) {
-        self.expandingPaginationWindow = NO;
         return;
     }
     
     BOOL moreMessagesAvailable = self.queryController.totalNumberOfObjects > ABS(self.queryController.paginationWindow);
     if (!moreMessagesAvailable) {
-        self.expandingPaginationWindow = NO;
         return;
     }
     
     NSUInteger numberOfMessagesToDisplay = MIN(-self.queryController.paginationWindow + ATLQueryControllerPaginationWindow, self.queryController.totalNumberOfObjects);
     self.queryController.paginationWindow = -numberOfMessagesToDisplay;
-    self.expandingPaginationWindow = NO;
 }
 
 - (BOOL)moreMessagesAvailable


### PR DESCRIPTION
* This PR removes the `expandingPaginationWindow` property from `ATLConversationDataSource`. The property is no longer relevant as updates reported by setting the pagination window on an `LYRQueryController` are no longer synchronous.

* Moved logic to track whether or not the query controller is updating its pagination window to the `ATLConversationViewController`. 

We should discuss adding a `isExpandingPaginationWindow` property to `LYRQueryController`, but for now, this will do. 