### PR TITLE
Fix the Carthage build

### DIFF
--- a/Resources/Info.plist
+++ b/Resources/Info.plist
@@ -4,6 +4,8 @@
 <dict>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
 	<key>CFBundleIdentifier</key>
 	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
 	<key>CFBundleInfoDictionaryVersion</key>

--- a/Resources/Info.plist
+++ b/Resources/Info.plist
@@ -11,7 +11,7 @@
 	<key>CFBundleName</key>
 	<string>$(PRODUCT_NAME)</string>
 	<key>CFBundlePackageType</key>
-	<string>BNDL</string>
+	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
 	<string>1.0</string>
 	<key>CFBundleSignature</key>


### PR DESCRIPTION
As pointed out by the issue [Carthage#1096](https://github.com/Carthage/Carthage/issues/1096) and [Carthage#1077](https://github.com/Carthage/Carthage/issues/1077) : 
The `CFBundlePackageType` value of the Info.plist was `BNDL`, but it needs to be `FMWK`.

Except if `BNDL` has been set on purpose ^^ which I'm about to find out I guess.

Plus it was missing a `CFBundleExecutable` entry in the Info.plist

Cheers