### PR TITLE
Incorrect deletionModes type

### DIFF
--- a/Code/Controllers/ATLConversationListViewController.m
+++ b/Code/Controllers/ATLConversationListViewController.m
@@ -327,7 +327,7 @@ NSString *const ATLConversationListViewControllerDeletionModeEveryone = @"Everyo
 {
     NSMutableArray *actions = [NSMutableArray new];
     if ([self.dataSource respondsToSelector:@selector(conversationListViewController:rowActionsForDeletionModes:)]) {
-        NSArray *customActions = [self.dataSource conversationListViewController:self rowActionsForDeletionModes:self.deletionModes];
+        NSArray *customActions = [self.dataSource conversationListViewController:self rowActionsForDeletionModes:(NSArray<UITableViewRowAction *> *)self.deletionModes];
         for (id action in customActions) {
             if (![action isKindOfClass:[UITableViewRowAction class]]) {
                 @throw [NSException exceptionWithName:NSInternalInconsistencyException reason:@"must supply an array of `UITableViewRowAction` objects" userInfo:nil];


### PR DESCRIPTION
After fixing #1139 I found that using Xcode 7.3 Altlas still won't build using carthage:
```objc
ATLConversationListViewController.m:330:114: error: incompatible pointer types sending 'NSArray<NSNumber *> *' to parameter of type 'NSArray<UITableViewRowAction *> * _Nonnull' [-Werror,-Wincompatible-pointer-types]
        NSArray *customActions = [self.dataSource conversationListViewController:self rowActionsForDeletionModes:self.deletionModes];
                                                                                                                 ^~~~~~~~~~~~~~~~~~

In file included from […]/Atlas-iOS/Code/Controllers/ATLConversationListViewController.m:22:
[…]/Atlas-iOS/Code/Controllers/ATLConversationListViewController.h:130:176: note: passing argument to parameter 'deletionModes' here
- (NSArray *)conversationListViewController:(ATLConversationListViewController *)conversationListViewController rowActionsForDeletionModes:(NSArray < UITableViewRowAction*> *)deletionModes;
```

Seems that the SDK/compiler got more picky or the method signature changed. 

Not sure why using carthage this is an error while compiling using Xcode just gives a warning. I silenced the warning/error for now casting to the correct type for now. Not sure if this is just hiding a bug…


