### PR TITLE
Fix bug where activity indicator wouldn't dismiss

### DIFF
--- a/Code/Models/ATLConversationDataSource.m
+++ b/Code/Models/ATLConversationDataSource.m
@@ -145,7 +145,7 @@ NSInteger const ATLQueryControllerPaginationWindow = 30;
 
 - (NSUInteger)messagesAvailableRemotely
 {
-    return MAX(0, self.conversation.totalNumberOfMessages - ABS(self.queryController.count));
+    return MAX(0, (int)self.conversation.totalNumberOfMessages - ABS((int)self.queryController.count));
 }
 
 - (NSIndexPath *)queryControllerIndexPathForCollectionViewIndexPath:(NSIndexPath *)collectionViewIndexPath


### PR DESCRIPTION
To reproduce this bug, send the first message in a conversation,
and the activity indicator will persist forever.

The reason is because the MAX in `messagesAvailableRemotely`
wasn't working properly, and so it wasn't properly capping the
method at 0.