### PR TITLE
Removing executable key from info plist

### DIFF
--- a/Resources/Info.plist
+++ b/Resources/Info.plist
@@ -20,7 +20,5 @@
 	<string>$(CURRENT_PROJECT_VERSION)</string>
 	<key>NSPrincipalClass</key>
 	<string></string>
-	<key>CFBundleExecutable</key>
-	<string>Atlas</string>
 </dict>
 </plist>


### PR DESCRIPTION
* Removing executable key from info.plist to fix cocoapods builds.