### PR TITLE
APPS-2307 - Endless Spinner Fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Atlas Changelog
 
+## 1.0.21
+
+### Bug Fixes
+
+* Fixes an issue where a loading spinner wouldn't dissapear after pulling to load more messages in a conversation view controller.
+
 ## 1.0.20
 
 ### Enhancements

--- a/Code/Models/ATLConversationDataSource.m
+++ b/Code/Models/ATLConversationDataSource.m
@@ -145,7 +145,7 @@ NSInteger const ATLQueryControllerPaginationWindow = 30;
 
 - (NSUInteger)messagesAvailableRemotely
 {
-    return MAX(0, self.conversation.totalNumberOfMessages - ABS(self.queryController.count));
+    return (NSUInteger)MAX((NSInteger)0, (NSInteger)self.conversation.totalNumberOfMessages - (NSInteger)ABS(self.queryController.count));
 }
 
 - (NSIndexPath *)queryControllerIndexPathForCollectionViewIndexPath:(NSIndexPath *)collectionViewIndexPath


### PR DESCRIPTION
Caused by an unsigned integer overflow in ATLConversationDataSource.