### PR TITLE
Tiny fix for ensuring spinner is removed when setting conversation

### DIFF
--- a/Code/Controllers/ATLConversationViewController.m
+++ b/Code/Controllers/ATLConversationViewController.m
@@ -256,7 +256,7 @@ static NSInteger const ATLPhotoActionSheet = 1000;
     }
     self.conversationDataSource.queryController.delegate = self;
     self.queryController = self.conversationDataSource.queryController;
-    self.showingMoreMessagesIndicator = [self.conversationDataSource moreMessagesAvailable];
+    self.showingMoreMessagesIndicator = NO;
     [self.collectionView reloadData];
 }
 


### PR DESCRIPTION
* Partial sync caused this bug to pop up. When you set a new conversation that has historical content, it could throw off the logic used to display the spinner. This pr removes the edge case.