### PR TITLE
Adds phone numbers recognizer for chat message

### DIFF
--- a/Code/Views/ATLMessageBubbleView.m
+++ b/Code/Views/ATLMessageBubbleView.m
@@ -85,6 +85,7 @@ typedef NS_ENUM(NSInteger, ATLBubbleViewContentType) {
         [self addSubview:_bubbleViewLabel];
         
         _textCheckingTypes = NSTextCheckingTypeLink;
+        _textCheckingTypes = NSTextCheckingTypePhoneNumber;
         
         _bubbleImageView = [[UIImageView alloc] init];
         _bubbleImageView.translatesAutoresizingMaskIntoConstraints = NO;

--- a/Code/Views/ATLMessageCollectionViewCell.m
+++ b/Code/Views/ATLMessageCollectionViewCell.m
@@ -93,6 +93,7 @@ NSInteger const kATLSharedCellTag = 1000;
     _messageTextColor = [UIColor blackColor];
     _messageLinkTextColor = [UIColor whiteColor];
     _messageTextCheckingTypes = NSTextCheckingTypeLink;
+    _messageTextCheckingTypes = NSTextCheckingTypePhoneNumber;
     _imageProcessingConcurrentQueue = dispatch_queue_create(ATLMessageCollectionViewCellImageProcessingConcurrentQueue, DISPATCH_QUEUE_CONCURRENT);
     [self.bubbleView updateProgressIndicatorWithProgress:0.0 visible:NO animated:NO];
 }


### PR DESCRIPTION
Phone numbers are currently not recognized on the chat messages, visually and on gestures, because NSTextCheckingType was not set to look for phone numbers. I added it for both the UI and the gesture tap on message.