### PR TITLE
Created protocols and delegate to handle custom input views

### DIFF
--- a/Atlas.xcodeproj/project.pbxproj
+++ b/Atlas.xcodeproj/project.pbxproj
@@ -96,6 +96,7 @@
 		427E3A203E8300A1E7A18A4F /* Pods_UnitTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = ED379E4FE835A9A9C48091B7 /* Pods_UnitTests.framework */; };
 		5A86A2D11B82BB11005AF74B /* ATLMessageCollectionViewCellTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 5A86A2D01B82BB11005AF74B /* ATLMessageCollectionViewCellTests.m */; };
 		5A86A2D21B82BB11005AF74B /* ATLMessageCollectionViewCellTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 5A86A2D01B82BB11005AF74B /* ATLMessageCollectionViewCellTests.m */; };
+		5AB61E101CC5B26F00FE463F /* ATLInputView.h in Headers */ = {isa = PBXBuildFile; fileRef = 5AB61E0F1CC5B26F00FE463F /* ATLInputView.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		5AEF68811C75284300808463 /* LYRIdentity+ATLParticipant.h in Headers */ = {isa = PBXBuildFile; fileRef = 5AEF687F1C75284300808463 /* LYRIdentity+ATLParticipant.h */; };
 		5AEF68821C75284300808463 /* LYRIdentity+ATLParticipant.m in Sources */ = {isa = PBXBuildFile; fileRef = 5AEF68801C75284300808463 /* LYRIdentity+ATLParticipant.m */; };
 		5AEFC5CB1B79834300ADE4EC /* boatgif.gif in Resources */ = {isa = PBXBuildFile; fileRef = 5AEFC5CA1B79834300ADE4EC /* boatgif.gif */; };
@@ -282,6 +283,7 @@
 		511D715DFD8A8962334A2194 /* Pods-UnitTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-UnitTests.debug.xcconfig"; path = "Pods/Target Support Files/Pods-UnitTests/Pods-UnitTests.debug.xcconfig"; sourceTree = "<group>"; };
 		55792E6A592D8AB80A1C483E /* Pods_ProgrammaticTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_ProgrammaticTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		5A86A2D01B82BB11005AF74B /* ATLMessageCollectionViewCellTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = ATLMessageCollectionViewCellTests.m; path = Tests/ATLMessageCollectionViewCellTests.m; sourceTree = "<group>"; };
+		5AB61E0F1CC5B26F00FE463F /* ATLInputView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ATLInputView.h; sourceTree = "<group>"; };
 		5AEF687F1C75284300808463 /* LYRIdentity+ATLParticipant.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "LYRIdentity+ATLParticipant.h"; sourceTree = "<group>"; };
 		5AEF68801C75284300808463 /* LYRIdentity+ATLParticipant.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "LYRIdentity+ATLParticipant.m"; sourceTree = "<group>"; };
 		5AEFC5CA1B79834300ADE4EC /* boatgif.gif */ = {isa = PBXFileReference; lastKnownFileType = image.gif; path = boatgif.gif; sourceTree = "<group>"; };
@@ -488,6 +490,7 @@
 				253C29CA1C3C9E0000ED1549 /* ATLMessagePresenting.h */,
 				253C29CB1C3C9E0000ED1549 /* ATLParticipant.h */,
 				253C29CC1C3C9E0000ED1549 /* ATLParticipantPresenting.h */,
+				5AB61E0F1CC5B26F00FE463F /* ATLInputView.h */,
 			);
 			path = Protocols;
 			sourceTree = "<group>";
@@ -787,6 +790,7 @@
 				253C2A261C3C9E0000ED1549 /* ATLMediaInputStream.h in Headers */,
 				253C2A131C3C9E0000ED1549 /* ATLConversationDataSource.h in Headers */,
 				253C2A521C3C9E0000ED1549 /* ATLPlayView.h in Headers */,
+				5AB61E101CC5B26F00FE463F /* ATLInputView.h in Headers */,
 				253C2A4A1C3C9E0000ED1549 /* ATLMessageInputToolbar.h in Headers */,
 				253C2A321C3C9E0000ED1549 /* ATLAddressBarView.h in Headers */,
 				253C2A3C1C3C9E0000ED1549 /* ATLConversationCollectionViewMoreMessagesHeader.h in Headers */,

--- a/Code/Controllers/ATLConversationViewController.h
+++ b/Code/Controllers/ATLConversationViewController.h
@@ -32,6 +32,7 @@ typedef NS_ENUM(NSUInteger, ATLAvatarItemDisplayFrequency) {
 
 @class ATLConversationViewController;
 @protocol ATLMessagePresenting;
+@protocol ATLInputView;
 
 ///---------------------------------------
 /// @name Delegate
@@ -98,6 +99,16 @@ NS_ASSUME_NONNULL_BEGIN
  a call to `registerClass:forMessageCellWithReuseIdentifier:`. They should also implement the optional data source method, `conversationViewController:reuseIdentifierForMessage:`.
  */
 - (NSOrderedSet <LYRMessage*> *)conversationViewController:(ATLConversationViewController *)viewController messagesForMediaAttachments:(NSArray <ATLMediaAttachment*> *)mediaAttachments;
+
+/**
+ @abstract Asks the delegate for an `NSArray` of views that conform to the `ATLInputview` protocol.
+ @param viewController The `ATLConversationViewController` instance that will use the input views.
+ @return An `NSArray` of `UIView` objects that conform to `ATLInputView`. If `nil` is returned, the controller will fall back to default behavior.
+ @discussion This is called whenever the user taps the left accessory icon, and is a way to extend Atlas functionality.  Input views added here will be selectable
+ based on their `title` property defined from the `ATLInputview` protocol, and the inputView will be shown.  It is up to the application to handle content selection,
+ message creation, and message sending, as well as resetting of the inputview.
+ */
+- (NSArray <ATLInputView> *)inputViewsForConversationViewController:(ATLConversationViewController *)viewController;
 
 @end
 

--- a/Code/Protocols/ATLInputView.h
+++ b/Code/Protocols/ATLInputView.h
@@ -1,0 +1,33 @@
+//
+//  ATLInputView.h
+//  Atlas
+//
+//  Created by Kabir Mahal on 4/18/16.
+//  Copyright (c) 2016 Layer, Inc. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+#import <Foundation/Foundation.h>
+
+/**
+ @abstract The `ATLInputView` allows for custom input views to be used within the `ATLConversationViewController`.
+ */
+@protocol ATLInputView <NSObject>
+
+/**
+ @abstract The title that should be used when displaying the input view option when the message input toolbar left accessory button is tapped.
+ */
+@property (nonatomic, readonly) NSString *title;
+
+@end

--- a/Code/Views/ATLMessageInputToolbar.m
+++ b/Code/Views/ATLMessageInputToolbar.m
@@ -338,6 +338,12 @@ static CGFloat const ATLButtonHeight = 28.0f;
     return YES;
 }
 
+- (void)textViewDidBeginEditing:(UITextView *)textView
+{
+    self.textInputView.inputView = nil;
+    [self.textInputView reloadInputViews];
+}
+
 #pragma mark - Helpers
 
 - (NSArray *)mediaAttachmentsFromAttributedString:(NSAttributedString *)attributedString

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -7,7 +7,7 @@ PODS:
   - KIF/Core (3.4.2)
   - KIFViewControllerActions (1.0.1):
     - KIF (>= 2.0.0)
-  - LayerKit (0.20.2)
+  - LayerKit (0.20.4)
   - LYRCountDownLatch (0.9.0)
   - OCMock (3.2.2)
 
@@ -40,7 +40,7 @@ SPEC CHECKSUMS:
   Expecta: e1c022fcd33910b6be89c291d2775b3fe27a89fe
   KIF: b518c9831453abea5afdbbde3908ec47832d6d56
   KIFViewControllerActions: 8d2f9ec9f185fa70ca9f54a297de544afe71ea55
-  LayerKit: 78419d6b6b5bf3bff317c982d4dab37897e9f895
+  LayerKit: c26dbe78f066e0d9ecea814942ddf15a68990ad5
   LYRCountDownLatch: 9b440b42a19ddbf4e75bdd4b43726baa1527606a
   OCMock: 18c9b7e67d4c2770e95bb77a9cc1ae0c91fe3835
 


### PR DESCRIPTION
This PR allows Atlas to be used with any number of input views for 3rd party library integration. 
1. New `ATLInputView` protocol that all input views would have to implement
2. The new `ATLConversationViewController` delegate `inputViewsForConversationViewController` that takes an array of input views that conform to `ATLInputView`
3. The message input toolbar's left accessory button's action sheet would now have new actionable items defined from the protocol.
4. Atlas handles transitioning from a keyboard to an inputview, and back.