### PR TITLE
Adds phone numbers recognizer for chat message (for real 😀 )

### DIFF
--- a/Code/Views/ATLMessageBubbleView.m
+++ b/Code/Views/ATLMessageBubbleView.m
@@ -85,6 +85,7 @@ typedef NS_ENUM(NSInteger, ATLBubbleViewContentType) {
         [self addSubview:_bubbleViewLabel];
         
         _textCheckingTypes = NSTextCheckingTypeLink;
+        _textCheckingTypes = NSTextCheckingTypePhoneNumber;
         
         _bubbleImageView = [[UIImageView alloc] init];
         _bubbleImageView.translatesAutoresizingMaskIntoConstraints = NO;

--- a/Code/Views/ATLMessageBubbleView.m
+++ b/Code/Views/ATLMessageBubbleView.m
@@ -84,7 +84,7 @@ typedef NS_ENUM(NSInteger, ATLBubbleViewContentType) {
         [_bubbleViewLabel setContentCompressionResistancePriority:UILayoutPriorityDefaultHigh + 1 forAxis:UILayoutConstraintAxisHorizontal];
         [self addSubview:_bubbleViewLabel];
         
-        _textCheckingTypes = NSTextCheckingTypeLink|NSTextCheckingTypePhoneNumber;
+        _textCheckingTypes = NSTextCheckingTypeLink | NSTextCheckingTypePhoneNumber;
         
         _bubbleImageView = [[UIImageView alloc] init];
         _bubbleImageView.translatesAutoresizingMaskIntoConstraints = NO;

--- a/Code/Views/ATLMessageBubbleView.m
+++ b/Code/Views/ATLMessageBubbleView.m
@@ -84,8 +84,7 @@ typedef NS_ENUM(NSInteger, ATLBubbleViewContentType) {
         [_bubbleViewLabel setContentCompressionResistancePriority:UILayoutPriorityDefaultHigh + 1 forAxis:UILayoutConstraintAxisHorizontal];
         [self addSubview:_bubbleViewLabel];
         
-        _textCheckingTypes = NSTextCheckingTypeLink;
-        _textCheckingTypes = NSTextCheckingTypePhoneNumber;
+        _textCheckingTypes = NSTextCheckingTypeLink|NSTextCheckingTypePhoneNumber;
         
         _bubbleImageView = [[UIImageView alloc] init];
         _bubbleImageView.translatesAutoresizingMaskIntoConstraints = NO;

--- a/Code/Views/ATLMessageCollectionViewCell.m
+++ b/Code/Views/ATLMessageCollectionViewCell.m
@@ -92,7 +92,7 @@ NSInteger const kATLSharedCellTag = 1000;
     _messageTextFont = [UIFont systemFontOfSize:17];
     _messageTextColor = [UIColor blackColor];
     _messageLinkTextColor = [UIColor whiteColor];
-    _messageTextCheckingTypes = NSTextCheckingTypeLink|NSTextCheckingTypePhoneNumber;
+    _messageTextCheckingTypes = NSTextCheckingTypeLink | NSTextCheckingTypePhoneNumber;
     _imageProcessingConcurrentQueue = dispatch_queue_create(ATLMessageCollectionViewCellImageProcessingConcurrentQueue, DISPATCH_QUEUE_CONCURRENT);
     [self.bubbleView updateProgressIndicatorWithProgress:0.0 visible:NO animated:NO];
 }

--- a/Code/Views/ATLMessageCollectionViewCell.m
+++ b/Code/Views/ATLMessageCollectionViewCell.m
@@ -92,8 +92,7 @@ NSInteger const kATLSharedCellTag = 1000;
     _messageTextFont = [UIFont systemFontOfSize:17];
     _messageTextColor = [UIColor blackColor];
     _messageLinkTextColor = [UIColor whiteColor];
-    _messageTextCheckingTypes = NSTextCheckingTypeLink;
-    _messageTextCheckingTypes = NSTextCheckingTypePhoneNumber;
+    _messageTextCheckingTypes = NSTextCheckingTypeLink|NSTextCheckingTypePhoneNumber;
     _imageProcessingConcurrentQueue = dispatch_queue_create(ATLMessageCollectionViewCellImageProcessingConcurrentQueue, DISPATCH_QUEUE_CONCURRENT);
     [self.bubbleView updateProgressIndicatorWithProgress:0.0 visible:NO animated:NO];
 }

--- a/Code/Views/ATLMessageCollectionViewCell.m
+++ b/Code/Views/ATLMessageCollectionViewCell.m
@@ -93,6 +93,7 @@ NSInteger const kATLSharedCellTag = 1000;
     _messageTextColor = [UIColor blackColor];
     _messageLinkTextColor = [UIColor whiteColor];
     _messageTextCheckingTypes = NSTextCheckingTypeLink;
+    _messageTextCheckingTypes = NSTextCheckingTypePhoneNumber;
     _imageProcessingConcurrentQueue = dispatch_queue_create(ATLMessageCollectionViewCellImageProcessingConcurrentQueue, DISPATCH_QUEUE_CONCURRENT);
     [self.bubbleView updateProgressIndicatorWithProgress:0.0 visible:NO animated:NO];
 }


### PR DESCRIPTION
The NSDataDetector was missing the phone number type which prevents to visually identify phone numbers in chat messages(with color and underscore) and it was also preventing the gesture recognizer to trigger the proper action, upon phone number type notification.