### PR TITLE
Custom cells for ATLAddresBarViewController.

### DIFF
--- a/Code/Controllers/ATLAddressBarViewController.h
+++ b/Code/Controllers/ATLAddressBarViewController.h
@@ -20,7 +20,7 @@
 
 #import <UIKit/UIKit.h>
 #import "ATLAddressBarView.h"
-#import "ATLParticipant.h"
+#import "ATLParticipantTableViewCell.h"
 
 @class ATLAddressBarViewController;
 
@@ -105,6 +105,37 @@ NS_ASSUME_NONNULL_BEGIN
  a UIButton object represented by the `addContactButton` property.
  */
 @property (nonatomic) ATLAddressBarView *addressBarView;
+
+///----------------------------------------
+/// @name Configuring the Participants List
+///----------------------------------------
+
+/**
+ @abstract The color for the title label displayed in the default `ATLAddressBarViewController` cell. Default is `ATLBlueColor()`.
+ */
+@property (nonatomic) UIColor *defaultCellTitleColor;
+
+/**
+ @abstract The `UITableViewCell` subclass for customizing the display of participants.
+ @discussion If you wish to provide your own custom class, your class must conform to the `ATLParticipantPresenting` protocol.
+ @default `ATLParticipantTableViewCell.h`
+ @raises NSInternalInconsistencyException Raised if the value is mutated after the receiver has been presented.
+ */
+@property (nonatomic) Class<ATLParticipantPresenting> cellClass;
+
+/**
+ @abstract Sets the height for cells within the receiver.
+ @default `56.0`
+ @raises NSInternalInconsistencyException Raised if the value is mutated after the receiver has been presented.
+ */
+@property (nonatomic, assign) CGFloat rowHeight;
+
+/**
+ @abstract Defines the sort ordering of the participant list.
+ @default `ATLParticipantPickerSortTypeFirstName`.
+ @raises NSInternalInconsistencyException Raised if the value is mutated after the receiver has been presented.
+ */
+@property (nonatomic, assign) ATLParticipantPickerSortType sortType;
 
 ///----------------------
 // @name UI Configuration

--- a/Code/Controllers/ATLAddressBarViewController.m
+++ b/Code/Controllers/ATLAddressBarViewController.m
@@ -18,6 +18,7 @@
 //  limitations under the License.
 //
 
+#import <objc/runtime.h>
 #import "ATLAddressBarViewController.h"
 #import "ATLConstants.h"
 #import "ATLAddressBarContainerView.h"
@@ -29,6 +30,7 @@
 @property (nonatomic) UITableView *tableView;
 @property (nonatomic) NSArray *participants;
 @property (nonatomic, getter=isDisabled) BOOL disabled;
+@property (nonatomic) BOOL hasAppeared;
 
 @end
 
@@ -49,6 +51,10 @@ static NSString *const ATLAddressBarParticipantAttributeName = @"ATLAddressBarPa
 {
     [super viewDidLoad];
     self.shouldShowParticipantAvatars = NO;
+    self.defaultCellTitleColor = ATLBlueColor();
+    self.sortType = ATLParticipantPickerSortTypeFirstName;
+    self.rowHeight = 56.f;
+    self.cellClass = [ATLParticipantTableViewCell class];
     self.view.accessibilityLabel = ATLAddressBarAccessibilityLabel;
     self.view.translatesAutoresizingMaskIntoConstraints = NO;
     
@@ -65,13 +71,27 @@ static NSString *const ATLAddressBarParticipantAttributeName = @"ATLAddressBarPa
     self.tableView.delegate = self;
     self.tableView.dataSource = self;
     self.tableView.rowHeight = 56;
-    [self.tableView registerClass:[ATLParticipantTableViewCell class] forCellReuseIdentifier:ATLMParticpantCellIdentifier];
     self.tableView.keyboardDismissMode = UIScrollViewKeyboardDismissModeOnDrag;
     self.tableView.hidden = YES;
     [self.view addSubview:self.tableView];
     
     [self configureLayoutConstraintsForAddressBarView];
     [self configureLayoutConstraintsForTableView];
+}
+
+-(void)viewWillAppear:(BOOL)animated
+{
+    [super viewWillAppear:animated];
+    if (!self.hasAppeared) {
+        self.tableView.rowHeight = self.rowHeight;
+        [self.tableView registerClass:self.cellClass forCellReuseIdentifier:ATLMParticpantCellIdentifier];
+    }
+}
+
+-(void)viewDidAppear:(BOOL)animated
+{
+    [super viewDidAppear:animated];
+    self.hasAppeared = YES;
 }
 
 #pragma mark - Public Method Implementation
@@ -137,6 +157,49 @@ static NSString *const ATLAddressBarParticipantAttributeName = @"ATLAddressBarPa
     [self.tableView reloadData];
 }
 
+#pragma mark - Public Setters
+
+- (void)setDefaultCellTitleColor:(UIColor *)defaultCellTitleColor
+{
+    _defaultCellTitleColor = defaultCellTitleColor;
+    [[ATLParticipantTableViewCell appearanceWhenContainedIn:[self class], nil] setTitleColor:self.defaultCellTitleColor];
+}
+
+- (void)setCellClass:(Class<ATLParticipantPresenting>)cellClass
+{
+    if (self.hasAppeared) {
+        @throw [NSException exceptionWithName:NSInternalInconsistencyException reason:@"Cannot change cell class after the view has been presented" userInfo:nil];
+    }
+    if (!class_conformsToProtocol(cellClass, @protocol(ATLParticipantPresenting))) {
+        @throw [NSException exceptionWithName:NSInternalInconsistencyException reason:@"Cell class must conform to ATLParticipantPresenting" userInfo:nil];
+    }
+    _cellClass = cellClass;
+}
+
+- (void)setRowHeight:(CGFloat)rowHeight
+{
+    if (self.hasAppeared) {
+        @throw [NSException exceptionWithName:NSInternalInconsistencyException reason:@"Cannot change row height after view has been presented" userInfo:nil];
+    }
+    _rowHeight = rowHeight;
+}
+
+- (void)setShouldShowParticipantAvatars:(BOOL)shouldShowParticipantAvatars
+{
+    if (self.hasAppeared) {
+        @throw [NSException exceptionWithName:NSInternalInconsistencyException reason:@"Cannot change participant avatar display after the view has been presented" userInfo:nil];
+    }
+    _shouldShowParticipantAvatars = shouldShowParticipantAvatars;
+}
+
+- (void)setSortType:(ATLParticipantPickerSortType)sortType
+{
+    if (self.hasAppeared) {
+        @throw [NSException exceptionWithName:NSInternalInconsistencyException reason:@"Cannot change sort type after view has been presented" userInfo:nil];
+    }
+    _sortType = sortType;
+}
+
 #pragma mark - UITableViewDataSource
 
 - (NSInteger)numberOfSectionsInTableView:(UITableView *)tableView
@@ -152,11 +215,8 @@ static NSString *const ATLAddressBarParticipantAttributeName = @"ATLAddressBarPa
 - (UITableViewCell *)tableView:(UITableView *)tableView cellForRowAtIndexPath:(NSIndexPath *)indexPath
 {
     ATLParticipantTableViewCell *cell = [tableView dequeueReusableCellWithIdentifier:ATLMParticpantCellIdentifier];
-    cell.titleFont = ATLMediumFont(16);
-    cell.titleColor = ATLBlueColor();
-    cell.shouldBoldTitle = NO;
-    id<ATLParticipant> participant = self.participants[indexPath.row];
-    [cell presentParticipant:participant withSortType:ATLParticipantPickerSortTypeFirstName shouldShowAvatarItem:self.shouldShowParticipantAvatars];
+
+    [self configureCell:cell atIndexPath:indexPath];
     return cell;
 }
 
@@ -164,6 +224,14 @@ static NSString *const ATLAddressBarParticipantAttributeName = @"ATLAddressBarPa
 {
     id<ATLParticipant> participant = self.participants[indexPath.row];
     [self selectParticipant:participant];
+}
+
+#pragma mark - Cell Configuration
+
+- (void)configureCell:(UITableViewCell<ATLParticipantPresenting> *)participantCell atIndexPath:(NSIndexPath *)indexPath
+{
+    id<ATLParticipant> participant = self.participants[indexPath.row];
+    [participantCell presentParticipant:participant withSortType:self.sortType shouldShowAvatarItem:self.shouldShowParticipantAvatars];
 }
 
 #pragma mark - UIScrollViewDelegate


### PR DESCRIPTION
Added ability to add custom cells for ATLAddresBarViewController. The default cell is ATLParticipantTableViewCell and all the default values are the same.