### PR TITLE
[Podspec] Remove header_mappings_dir

### DIFF
--- a/Atlas.podspec
+++ b/Atlas.podspec
@@ -17,7 +17,6 @@ Pod::Spec.new do |s|
   s.source_files                = 'Code/**/*.{h,m}'
   s.public_header_files         = 'Code/**/*.h'
   s.ios.resource_bundle         = { 'AtlasResource' => 'Resources/*' }
-  s.header_mappings_dir         = 'Code'
   s.ios.frameworks              = %w{ UIKit CoreLocation MobileCoreServices }
   s.ios.deployment_target       = '8.0'
   s.dependency                  'LayerKit', '>= 0.20.2'


### PR DESCRIPTION
As all imports assume that the "Code" directory is recursively searched for headers, I'd encourage to not specify a `header_mappings_dir` as this will conserve the directory structure in the header folder within the framework. While a target setup like that itself still compiles fine that causes that the imports of the public headers can't be resolved by the compiler frontend when importing the module as these imports assume a flattened out structure or headers being recursively searched. The latter would need to happen within the framework to avoid Clang complaining about "include of non-modular header inside framework module". That would be generally possible, but isn't implemented by CocoaPods so far.