### PR TITLE
Feature/support reloading of participants

### DIFF
--- a/Code/Controllers/ATLParticipantTableViewController.h
+++ b/Code/Controllers/ATLParticipantTableViewController.h
@@ -21,12 +21,13 @@
 #import <UIKit/UIKit.h>
 #import "ATLParticipantTableViewCell.h"
 
+NS_ASSUME_NONNULL_BEGIN
+
 @class ATLParticipantTableViewController;
 
 /**
  @abstract The `ATLParticipantViewControllerDelegate` protocol provides a method for notifying the adopting delegate about information changes.
  */
-NS_ASSUME_NONNULL_BEGIN
 @protocol ATLParticipantTableViewControllerDelegate <NSObject>
 
 /**
@@ -114,5 +115,12 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @property (nonatomic, assign) BOOL allowsMultipleSelection;
 
+/**
+ @abstract Reloads the cell for the given participant.
+ @param participant The participant object to reload the corresponding cell of. Cannot be `nil`.
+ */
+- (void)reloadCellForParticipant:(id<ATLParticipant>)participant;
+
 @end
+
 NS_ASSUME_NONNULL_END

--- a/Code/Controllers/ATLParticipantTableViewController.m
+++ b/Code/Controllers/ATLParticipantTableViewController.m
@@ -35,6 +35,7 @@ static NSString *const ATLParticipantCellIdentifier = @"ATLParticipantCellIdenti
 @property (nonatomic) NSMutableSet *selectedParticipants;
 @property (nonatomic) UISearchBar *searchBar;
 @property (nonatomic) BOOL hasAppeared;
+@property (nonatomic) dispatch_queue_t animationQueue;
 
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
@@ -79,7 +80,8 @@ NSString *const ATLParticipantTableViewControllerTitle = @"Participants";
     _cellClass = [ATLParticipantTableViewCell class];
     _rowHeight = 48;
     _allowsMultipleSelection = YES;
-    _selectedParticipants = [[NSMutableSet alloc] init];
+    _selectedParticipants = [NSMutableSet new];
+    _animationQueue = dispatch_queue_create("com.atlas.ATLParticipantTableViewController.animationQueue", DISPATCH_QUEUE_SERIAL);
 }
 
 - (void)loadView
@@ -176,6 +178,17 @@ NSString *const ATLParticipantTableViewControllerTitle = @"Participants";
         @throw [NSException exceptionWithName:NSInternalInconsistencyException reason:@"Cannot change sort type after view has been presented" userInfo:nil];
     }
     _sortType = sortType;
+}
+
+- (void)reloadCellForParticipant:(id<ATLParticipant>)participant
+{
+    dispatch_async(self.animationQueue, ^{
+        ATLParticipantTableDataSet *dataSet = [self dataSetForTableView:self.tableView];
+        NSIndexPath *indexPath = [dataSet indexPathForParticipant:participant];
+        if (indexPath) {
+            [self.tableView reloadRowsAtIndexPaths:[NSArray arrayWithObject:indexPath] withRowAnimation:UITableViewRowAnimationAutomatic];
+        }
+    });
 }
 
 #pragma mark - UISearchDisplayDelegate


### PR DESCRIPTION
These changes support reloading of cells for participants in Atlas. Currently you can wind up with `Unknown Participant` cells if identity synchronization is happening while the table view is on screen [APPS-2470]