### PR TITLE
added nullable keyword when needed in ATLConversationViewControllerDe…

### DIFF
--- a/Code/Controllers/ATLConversationListViewController.h
+++ b/Code/Controllers/ATLConversationListViewController.h
@@ -135,7 +135,7 @@ NS_ASSUME_NONNULL_BEGIN
  @return A string representing the content of the last message.  If `nil` is returned the controller will fall back to default behavior.
  @discussion This is used when the application uses custom `MIMEType`s and wants to customize how they are displayed.
  */
-- (NSString *)conversationListViewController:(ATLConversationListViewController *)conversationListViewController lastMessageTextForConversation:(LYRConversation *)conversation;
+- (nullable NSString *)conversationListViewController:(ATLConversationListViewController *)conversationListViewController lastMessageTextForConversation:(LYRConversation *)conversation;
 
 /**
  @abstract Asks the data source to configure the query used to fetch content for the controller if necessary.

--- a/Code/Controllers/ATLConversationViewController.h
+++ b/Code/Controllers/ATLConversationViewController.h
@@ -72,7 +72,7 @@ NS_ASSUME_NONNULL_BEGIN
  @discussion Applications should only return a value if the `message` object requires a custom cell class. If `nil` is returned, the collection view will default
  to internal height calculations.
  */
-- (CGFloat)conversationViewController:(ATLConversationViewController *)viewController heightForMessage:(LYRMessage *)message withCellWidth:(CGFloat)cellWidth;
+- (nullable CGFloat)conversationViewController:(ATLConversationViewController *)viewController heightForMessage:(LYRMessage *)message withCellWidth:(CGFloat)cellWidth;
 
 /**
  @abstract Informs the delegate of a cell being configured for the specified message.
@@ -97,7 +97,7 @@ NS_ASSUME_NONNULL_BEGIN
  current conversation for the controller. If implemented, applications should also register custom `UICollectionViewCell` classes with the controller via
  a call to `registerClass:forMessageCellWithReuseIdentifier:`. They should also implement the optional data source method, `conversationViewController:reuseIdentifierForMessage:`.
  */
-- (NSOrderedSet <LYRMessage*> *)conversationViewController:(ATLConversationViewController *)viewController messagesForMediaAttachments:(NSArray <ATLMediaAttachment*> *)mediaAttachments;
+- (nullable NSOrderedSet <LYRMessage*> *)conversationViewController:(ATLConversationViewController *)viewController messagesForMediaAttachments:(NSArray <ATLMediaAttachment*> *)mediaAttachments;
 
 @end
 


### PR DESCRIPTION
Hi, for now I wouldn't be able to use those delegate's methods in swift because I can't make it nil, the xCode won't let me because the nullable keyword wasn't used in it and we needed it in order to reuse default value if needed

Your product is awesome, thx