### PR TITLE
fix build error for the "Storyboard" target

### DIFF
--- a/Examples/Storyboard/StoryboardAppDelegate.m
+++ b/Examples/Storyboard/StoryboardAppDelegate.m
@@ -32,7 +32,7 @@
 - (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions
 {
     ATLUserMock *mockUser = [ATLUserMock userWithMockUserName:ATLMockUserNameBlake];
-    LYRClientMock *layerClient = [LYRClientMock layerClientMockWithAuthenticatedUserID:mockUser.participantIdentifier];
+    LYRClientMock *layerClient = [LYRClientMock layerClientMockWithAuthenticatedUserID:mockUser.userID];
     [[LYRMockContentStore sharedStore] hydrateConversationsForAuthenticatedUserID:layerClient.authenticatedUserID count:1];
     
     UINavigationController *navigationController = (UINavigationController *)[[[application delegate] window] rootViewController];


### PR DESCRIPTION
We'll  get the error below while build the "Storyboard" target.

```
error: property 'participantIdentifier' not found on object of type 'ATLUserMock *'
    LYRClientMock *layerClient = [LYRClientMock layerClientMockWithAuthenticatedUserID:mockUser.participantIdentifier];
```