### PR TITLE
Fix for NSInternalInconsistencyException when conversation is updated

### DIFF
--- a/Code/Controllers/ATLConversationViewController.m
+++ b/Code/Controllers/ATLConversationViewController.m
@@ -228,6 +228,7 @@ static NSInteger const ATLPhotoActionSheet = 1000;
     if (conversation) {
         [self fetchLayerMessages];
     } else {
+	self.conversationDataSource.queryController.delegate = nil;
         self.conversationDataSource = nil;
         [self.collectionView reloadData];
     }


### PR DESCRIPTION
This change fixes issue #1116 which happens with LayerKit v0.21.1 and Atlas v1.0.23.

When ATLConversationViewController is dismissed, conversationDataSource is set to nil but the query controller delegate is still bound to the controller. If a new message is received for the related conversation, conversationDataSource.queryController triggers the delegate to update the collection view, but numberOfSectionsInCollectionView in ATLConversationViewController returns 0+1, which causes the inconsistency.

The fix is unsetting the delegate so the query controller does not track changes when conversation view controller is dismissed. Updating the setConversation method in ATLConversationViewController fixes the issue.


