### PR TITLE
Fix for handling avatar visibility when using shouldDisplayAvatarItem

### DIFF
--- a/Code/Views/ATLBaseCollectionViewCell.h
+++ b/Code/Views/ATLBaseCollectionViewCell.h
@@ -48,6 +48,11 @@ extern CGFloat const ATLMessageCellHorizontalMargin;
 @property (nonatomic) ATLAvatarImageView *avatarImageView;
 
 /**
+ @abstract Determines if the cell should display the `ATLAvatarImageView`
+ */
+@property (nonatomic) BOOL shouldDisplayAvatar;
+
+/**
  @abstract The `LYRMessage` object passed in `ATLMessagePresenting` protocol `presentMessage:`.
  */
 @property (nonatomic) LYRMessage *message;

--- a/Code/Views/ATLBaseCollectionViewCell.m
+++ b/Code/Views/ATLBaseCollectionViewCell.m
@@ -35,7 +35,6 @@ CGFloat const ATLAvatarImageTailPadding = 4.0f;
 @property (nonatomic) NSLayoutConstraint *bubbleViewWidthConstraint;
 
 @property (nonatomic) BOOL messageSentState;
-@property (nonatomic) BOOL shouldDisplayAvatar;
 
 @end
 
@@ -107,6 +106,15 @@ CGFloat const ATLAvatarImageTailPadding = 4.0f;
     [self.contentView addConstraint:self.bubbleViewWidthConstraint];
 }
 
+- (void)setShouldDisplayAvatar:(BOOL)shouldDisplayAvatar
+{
+    if (shouldDisplayAvatar) {
+        self.avatarImageView.hidden = NO;
+    } else {
+        self.avatarImageView.hidden = YES;
+    }
+}
+
 - (void)presentMessage:(LYRMessage *)message
 {
     self.message = message;
@@ -131,10 +139,10 @@ CGFloat const ATLAvatarImageTailPadding = 4.0f;
 - (void)updateWithSender:(id<ATLParticipant>)sender
 {
     if (sender) {
-        self.avatarImageView.hidden = NO;
+        self.shouldDisplayAvatar = YES;
         self.avatarImageView.avatarItem = sender;
     } else {
-        self.avatarImageView.hidden = YES;
+        self.shouldDisplayAvatar = NO;
     }
 }
 


### PR DESCRIPTION
Exposes the shouldDisplayAvatar property of an ATLBaseCollectionViewCell.  This fixes the shouldDisplayAvatarItem method by allowing it to set the visibility of the cell's ATLAvatarImageView even if a message has no sender.  Previously only updateWithSender was setting this, but not shouldDisplayAvatarItem.
