### PR TITLE
APPS-2490 - Updated code to support the new LayerKit API changes.

### DIFF
--- a/Atlas.podspec
+++ b/Atlas.podspec
@@ -19,5 +19,5 @@ Pod::Spec.new do |s|
   s.ios.resource_bundle         = { 'AtlasResource' => 'Resources/*' }
   s.ios.frameworks              = %w{ UIKit CoreLocation MobileCoreServices }
   s.ios.deployment_target       = '8.0'
-  s.dependency                  'LayerKit', '>= 0.21.0'
+  s.dependency                  'LayerKit', '~> 0.22.0'
 end

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Atlas Changelog
 
+## 1.0.25
+
+### Enhancements
+
+* Upgraded `LayerKit` to version `0.22.0`. Due to breaking API changes introduced in LayerKit, affected code has been fixed.
+
 ## 1.0.24
 
 ### Enhancements

--- a/Code/Controllers/ATLConversationViewController.m
+++ b/Code/Controllers/ATLConversationViewController.m
@@ -593,13 +593,13 @@ static NSInteger const ATLPhotoActionSheet = 1000;
 - (void)messageInputToolbarDidType:(ATLMessageInputToolbar *)messageInputToolbar
 {
     if (!self.conversation) return;
-    [self.conversation sendTypingIndicator:LYRTypingDidBegin];
+    [self.conversation sendTypingIndicator:LYRTypingIndicatorActionBegin];
 }
 
 - (void)messageInputToolbarDidEndTyping:(ATLMessageInputToolbar *)messageInputToolbar
 {
     if (!self.conversation) return;
-    [self.conversation sendTypingIndicator:LYRTypingDidFinish];
+    [self.conversation sendTypingIndicator:LYRTypingIndicatorActionFinish];
 }
 
 #pragma mark - Message Sending
@@ -782,14 +782,12 @@ static NSInteger const ATLPhotoActionSheet = 1000;
     if (!self.conversation) return;
     if (!notification.object) return;
     if (![notification.object isEqual:self.conversation]) return;
-    
-    NSString *participantID = notification.userInfo[LYRTypingIndicatorParticipantUserInfoKey];
-    NSNumber *statusNumber = notification.userInfo[LYRTypingIndicatorValueUserInfoKey];
-    LYRTypingIndicator status = statusNumber.unsignedIntegerValue;
-    if (status == LYRTypingDidBegin) {
-        [self.typingParticipantIDs addObject:participantID];
+
+    LYRTypingIndicator *typingIndicator = notification.userInfo[LYRTypingIndicatorObjectUserInfoKey];
+    if (typingIndicator.action == LYRTypingIndicatorActionBegin) {
+        [self.typingParticipantIDs addObject:typingIndicator.sender.userID];
     } else {
-        [self.typingParticipantIDs removeObject:participantID];
+        [self.typingParticipantIDs removeObject:typingIndicator.sender.userID];
     }
     [self updateTypingIndicatorOverlay:YES];
 }
@@ -1163,9 +1161,9 @@ static NSInteger const ATLPhotoActionSheet = 1000;
     conversation = [self existingConversationWithParticipantIdentifiers:participantIdentifiers];
     if (conversation) return conversation;
     
-    BOOL deliveryReceiptsEnabled = participants.count <= 5;
-    NSDictionary *options = @{LYRConversationOptionsDeliveryReceiptsEnabledKey: @(deliveryReceiptsEnabled)};
-    conversation = [self.layerClient newConversationWithParticipants:participantIdentifiers options:options error:nil];
+    LYRConversationOptions *conversationOptions = [LYRConversationOptions new];
+    conversationOptions.deliveryReceiptsEnabled = participants.count <= 5;
+    conversation = [self.layerClient newConversationWithParticipants:participantIdentifiers options:conversationOptions error:nil];
     return conversation;
 }
 

--- a/Code/Utilities/ATLMessagingUtilities.m
+++ b/Code/Utilities/ATLMessagingUtilities.m
@@ -194,9 +194,10 @@ LYRMessage *ATLMessageForParts(LYRClient *layerClient, NSArray *messageParts, NS
     defaultConfiguration.sound = pushSound;
     defaultConfiguration.category = ATLUserNotificationDefaultActionsCategoryIdentifier;
     
-    NSDictionary *options = @{ LYRMessageOptionsPushNotificationConfigurationKey: defaultConfiguration };
+    LYRMessageOptions *messageOptions = [LYRMessageOptions new];
+    messageOptions.pushNotificationConfiguration = defaultConfiguration;
     NSError *error;
-    LYRMessage *message = [layerClient newMessageWithParts:messageParts options:options error:&error];
+    LYRMessage *message = [layerClient newMessageWithParts:messageParts options:messageOptions error:&error];
     if (error) {
         return nil;
     }


### PR DESCRIPTION
A few breaking API changes have been introduced in LayerKit v0.22.0 and we need to update the all the affected references in Atlas.