### PR TITLE
Bump version check for content flashing workaround

### DIFF
--- a/Code/Controllers/ATLBaseConversationViewController.m
+++ b/Code/Controllers/ATLBaseConversationViewController.m
@@ -18,10 +18,12 @@
 //  limitations under the License.
 //
 
-#define SYSTEM_VERSION_LESS_THAN(v) ([[[UIDevice currentDevice] systemVersion] compare:v options:NSNumericSearch] == NSOrderedAscending)
-
 #import "ATLBaseConversationViewController.h"
 #import "ATLConversationView.h"
+
+static inline BOOL atl_systemVersionLessThan(NSString * _Nonnull systemVersion) {
+    return [[UIDevice currentDevice].systemVersion compare:systemVersion options:NSOrderedAscending];
+}
 
 @interface ATLBaseConversationViewController ()
 
@@ -152,7 +154,7 @@ static CGFloat const ATLMaxScrollDistanceFromBottom = 150;
     [super viewWillDisappear:animated];
     
     self.messageInputToolbar.translucent = NO;
-    if (SYSTEM_VERSION_LESS_THAN(@"9.0")) {
+    if (atl_systemVersionLessThan(@"10.0")) {
         // Workaround for view's content flashing onscreen after pop animation concludes on iOS 8.
         BOOL isPopping = ![self.navigationController.viewControllers containsObject:self];
         if (isPopping) {


### PR DESCRIPTION
This addresses #1266 by bumping the minimum required version to `@"9.0"`.

I also took the liberty to replace the macro with an inline function, since they benefit from being checked by the compiler.