### PR TITLE
Removed query controller delegate when a conversation is removed from…

### DIFF
--- a/Code/Controllers/ATLConversationViewController.m
+++ b/Code/Controllers/ATLConversationViewController.m
@@ -228,6 +228,7 @@ static NSInteger const ATLPhotoActionSheet = 1000;
     if (conversation) {
         [self fetchLayerMessages];
     } else {
+        self.conversationDataSource.queryController.delegate = nil;
         self.conversationDataSource = nil;
         [self.collectionView reloadData];
     }


### PR DESCRIPTION
… ATLConversationViewController. This fixes the following case:

1. Start a new conversation
2. Add a participant for an existing conversation so the collectionView loads those messages
3. Remove all participants
4. Send, from another device, a message to the conversation that was just unloaded
5. NSInternalInconsistencyException is thrown