### PR TITLE
APPS-2524 Conversation Pagination (MAK)

### DIFF
--- a/Code/Controllers/ATLConversationListViewController.m
+++ b/Code/Controllers/ATLConversationListViewController.m
@@ -559,7 +559,7 @@ NSString *const ATLConversationListViewControllerDeletionModeEveryone = @"Everyo
     }
 }
 
-- (void) expandPaginationWindow
+- (void)expandPaginationWindow
 {
     self.queryController.paginationWindow += self.queryController.paginationWindow + ATLConverstionListPaginationWindow < self.queryController.totalNumberOfObjects ? ATLConverstionListPaginationWindow : self.queryController.totalNumberOfObjects - self.queryController.paginationWindow;
 }


### PR DESCRIPTION
Adds pagination (using LYRQueryController.paginationWindow, set to 30). Pulls in the next page of conversations when scrolled close to the bottom of the table view. Activity spinner placed in table view footer while there are additional pages of conversations.

NOTE: There is another branch (APPS-2524-conversation-pagination) that attempts the same functionality. I created by own branch (signified with my initials MAK in the name) instead of using that one.