### PR TITLE
Observe object changes to identities in the participant list

### DIFF
--- a/Code/Controllers/ATLParticipantTableViewController.m
+++ b/Code/Controllers/ATLParticipantTableViewController.m
@@ -343,6 +343,7 @@ NSString *const ATLParticipantTableViewControllerTitle = @"Participants";
 - (void)layerClientObjectsDidChange:(NSNotification *)notification
 {
     NSArray *changes = notification.userInfo[LYRClientObjectChangesUserInfoKey];
+    NSInteger changeCount = 0;
     for (LYRObjectChange *change in changes) {
         // Interested only in LYRIdentity objects who are potential participants.
         if (![change.object isKindOfClass:[LYRIdentity class]]) {
@@ -357,28 +358,32 @@ NSString *const ATLParticipantTableViewControllerTitle = @"Participants";
         switch (change.type) {
             case LYRObjectChangeTypeCreate:
                 [self.unfilteredDataSet addParticipant:particpant];
+                changeCount++;
                 break;
 
             case LYRObjectChangeTypeUpdate:
                 [self.unfilteredDataSet particpant:particpant updatedProperty:change.property];
+                changeCount++;
                 break;
 
             case LYRObjectChangeTypeDelete:
                 [self.unfilteredDataSet removeParticipant:particpant];
+                changeCount++;
                 break;
 
             default:
                 NSAssert(YES, @"Unrecognized LYRObjectChangeType.");
-                continue;
                 break;
         }
     }
 
-    [self.tableView reloadData];
+    if (changeCount > 0) {
+        [self.tableView reloadData];
 
-    // Perform the search again to update self.filteredDataSet
-    if (self.searchController.isActive) {
-        [self searchDisplayController:self.searchController shouldReloadTableForSearchString:self.searchController.searchBar.text];
+        // Perform the search again to update self.filteredDataSet
+        if (self.searchController.isActive) {
+            [self searchDisplayController:self.searchController shouldReloadTableForSearchString:self.searchController.searchBar.text];
+        }
     }
 }
 

--- a/Code/Controllers/ATLParticipantTableViewController.m
+++ b/Code/Controllers/ATLParticipantTableViewController.m
@@ -35,6 +35,7 @@ static NSString *const ATLParticipantCellIdentifier = @"ATLParticipantCellIdenti
 @property (nonatomic) NSMutableSet *selectedParticipants;
 @property (nonatomic) UISearchBar *searchBar;
 @property (nonatomic) BOOL hasAppeared;
+@property (nonatomic) BOOL isObservingParticipants;
 
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
@@ -82,6 +83,11 @@ NSString *const ATLParticipantTableViewControllerTitle = @"Participants";
     _selectedParticipants = [[NSMutableSet alloc] init];
 }
 
+- (void)dealloc
+{
+    [self stopObservingParticipants];
+}
+
 - (void)loadView
 {
     self.view = [[UITableView alloc] initWithFrame:CGRectZero style:UITableViewStylePlain];
@@ -126,6 +132,7 @@ NSString *const ATLParticipantTableViewControllerTitle = @"Participants";
         self.tableView.allowsMultipleSelection = self.allowsMultipleSelection;
         [self.tableView registerClass:self.cellClass forCellReuseIdentifier:ATLParticipantCellIdentifier];
         self.unfilteredDataSet = [ATLParticipantTableDataSet dataSetWithParticipants:self.participants sortType:self.sortType];
+        [self startObservingParticipants];
         [self.tableView reloadData];
     }
 }
@@ -313,6 +320,67 @@ NSString *const ATLParticipantTableViewControllerTitle = @"Participants";
     ATLParticipantTableDataSet *dataSet = [self dataSetForTableView:tableView];
     NSIndexPath *indexPath = [dataSet indexPathForParticipant:participant];
     return indexPath;
+}
+
+#pragma mark - Notification Handlers
+
+- (void)startObservingParticipants
+{
+    if (!self.isObservingParticipants) {
+        [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(layerClientObjectsDidChange:) name:LYRClientObjectsDidChangeNotification object:nil];
+        self.isObservingParticipants = YES;
+    }
+}
+
+- (void)stopObservingParticipants
+{
+    if (self.isObservingParticipants) {
+        [[NSNotificationCenter defaultCenter] removeObserver:self name:LYRClientObjectsDidChangeNotification object:nil];
+        self.isObservingParticipants = NO;
+    }
+}
+
+- (void)layerClientObjectsDidChange:(NSNotification *)notification
+{
+    NSArray *changes = notification.userInfo[LYRClientObjectChangesUserInfoKey];
+    for (LYRObjectChange *change in changes) {
+        // Interested only in LYRIdentity objects who are potential participants.
+        if (![change.object isKindOfClass:[LYRIdentity class]]) {
+            continue;
+        }
+        if (![change.object conformsToProtocol:@protocol(ATLParticipant)]) {
+            continue;
+        }
+
+        id<ATLParticipant> particpant = change.object;
+
+        switch (change.type)
+        {
+            case LYRObjectChangeTypeCreate:
+                [self.unfilteredDataSet addParticipant:particpant];
+                break;
+
+            case LYRObjectChangeTypeUpdate:
+                [self.unfilteredDataSet particpant:particpant updatedProperty:change.property];
+                break;
+
+            case LYRObjectChangeTypeDelete:
+                [self.unfilteredDataSet removeParticipant:particpant];
+                break;
+
+            default:
+                NSAssert(YES, @"Unrecognized LYRObjectChangeType.");
+                continue;
+                break;
+        }
+    }
+
+    [self.tableView reloadData];
+
+    // Perform the search again to update self.filteredDataSet
+    if (self.searchController.isActive) {
+        [self searchDisplayController:self.searchController shouldReloadTableForSearchString:self.searchController.searchBar.text];
+    }
 }
 
 @end

--- a/Code/Controllers/ATLParticipantTableViewController.m
+++ b/Code/Controllers/ATLParticipantTableViewController.m
@@ -354,8 +354,7 @@ NSString *const ATLParticipantTableViewControllerTitle = @"Participants";
 
         id<ATLParticipant> particpant = change.object;
 
-        switch (change.type)
-        {
+        switch (change.type) {
             case LYRObjectChangeTypeCreate:
                 [self.unfilteredDataSet addParticipant:particpant];
                 break;

--- a/Code/Models/ATLParticipantTableDataSet.h
+++ b/Code/Models/ATLParticipantTableDataSet.h
@@ -32,6 +32,25 @@ NS_ASSUME_NONNULL_BEGIN
 + (instancetype)dataSetWithParticipants:(NSSet <id<ATLParticipant>>*)participants sortType:(ATLParticipantPickerSortType)sortType;
 
 /**
+ @abstract Adds a given participant to the data set, if it is not already a member. The data set responds by recalculating its section information.
+ @param participant The participant to add to the data set.
+ */
+- (void) addParticipant:(id<ATLParticipant>)participant;
+
+/**
+ @abstract Removes a given participant from the data set. The data set responds by recalculating its section information.
+ @param participant The participant to remove from the data set.
+ */
+- (void) removeParticipant:(id<ATLParticipant>)participant;
+
+/**
+ @abstract Notifies the data set that a property of an exiting participant in the set has changed. The data set responds by recalculating its section information if the property change affects the sort order of the data set.
+ @param participant The participant that has been modified.
+ @param participant The name of the property of the participant that has changed.
+ */
+- (void) particpant:(id<ATLParticipant>)participant updatedProperty:(NSString *)property;
+
+/**
  @abstract An array containing a string for each section.
  */
 @property (nonatomic, readonly) NSArray <NSString*> *sectionTitles;

--- a/Code/Models/ATLParticipantTableDataSet.h
+++ b/Code/Models/ATLParticipantTableDataSet.h
@@ -35,20 +35,20 @@ NS_ASSUME_NONNULL_BEGIN
  @abstract Adds a given participant to the data set, if it is not already a member. The data set responds by recalculating its section information.
  @param participant The participant to add to the data set.
  */
-- (void) addParticipant:(id<ATLParticipant>)participant;
+- (void)addParticipant:(id<ATLParticipant>)participant;
 
 /**
  @abstract Removes a given participant from the data set. The data set responds by recalculating its section information.
  @param participant The participant to remove from the data set.
  */
-- (void) removeParticipant:(id<ATLParticipant>)participant;
+- (void)removeParticipant:(id<ATLParticipant>)participant;
 
 /**
  @abstract Notifies the data set that a property of an exiting participant in the set has changed. The data set responds by recalculating its section information if the property change affects the sort order of the data set.
  @param participant The participant that has been modified.
  @param participant The name of the property of the participant that has changed.
  */
-- (void) particpant:(id<ATLParticipant>)participant updatedProperty:(NSString *)property;
+- (void)particpant:(id<ATLParticipant>)participant updatedProperty:(NSString *)property;
 
 /**
  @abstract An array containing a string for each section.

--- a/Code/Models/ATLParticipantTableDataSet.m
+++ b/Code/Models/ATLParticipantTableDataSet.m
@@ -89,7 +89,7 @@ static NSString *ATLInitialForName(NSString *name)
 
 #pragma mark -
 
-- (void) addParticipant:(id<ATLParticipant>)participant
+- (void)addParticipant:(id<ATLParticipant>)participant
 {
     if (![self.participants containsObject:participant]) {
         [self.participants addObject:participant];
@@ -97,7 +97,7 @@ static NSString *ATLInitialForName(NSString *name)
     }
 }
 
-- (void) removeParticipant:(id<ATLParticipant>)participant
+- (void)removeParticipant:(id<ATLParticipant>)participant
 {
     if ([self.participants containsObject:participant]) {
         [self.participants removeObject:participant];
@@ -105,7 +105,7 @@ static NSString *ATLInitialForName(NSString *name)
     }
 }
 
-- (void) particpant:(id<ATLParticipant>)participant updatedProperty:(NSString *)property
+- (void)particpant:(id<ATLParticipant>)participant updatedProperty:(NSString *)property
 {
     if ([self.participants containsObject:participant] && [self.sortDescriptor.key isEqualToString:property]) {
         self.sectionsNeedUpdating = YES;
@@ -163,7 +163,7 @@ static NSString *ATLInitialForName(NSString *name)
 
 #pragma mark -
 
-- (void) updateSectionsIfNeeded
+- (void)updateSectionsIfNeeded
 {
     if (!self.sectionsNeedUpdating) {
         return;

--- a/Code/Models/ATLParticipantTableDataSet.m
+++ b/Code/Models/ATLParticipantTableDataSet.m
@@ -21,6 +21,25 @@
 
 static NSString *const ATLParticipantTableMiscellaneaSectionTitle = @"#";
 
+static NSString *ATLInitialForName(NSString *name)
+{
+    if (name.length == 0) {
+        return ATLParticipantTableMiscellaneaSectionTitle;
+    }
+    NSString *initial = [name substringToIndex:1];
+    initial = [initial decomposedStringWithCanonicalMapping];
+    if (initial.length > 1) {
+        initial = [initial substringToIndex:1];
+    }
+    initial = initial.uppercaseString;
+    NSCharacterSet *uppercaseCharacters = [NSCharacterSet uppercaseLetterCharacterSet];
+    NSRange range = [initial rangeOfCharacterFromSet:uppercaseCharacters];
+    if (range.location == NSNotFound) {
+        return ATLParticipantTableMiscellaneaSectionTitle;
+    }
+    return initial;
+}
+
 @interface ATLParticipantTableSectionData : NSObject
 
 @property (nonatomic) NSRange participantsRange;
@@ -33,9 +52,12 @@ static NSString *const ATLParticipantTableMiscellaneaSectionTitle = @"#";
 
 @interface ATLParticipantTableDataSet ()
 
+@property (nonatomic) NSMutableArray *participants;
+@property (nonatomic) ATLParticipantPickerSortType sortType;
+@property (nonatomic) NSSortDescriptor *sortDescriptor;
 @property (nonatomic) NSArray *sectionTitles;
-@property (nonatomic) NSArray *participants;
 @property (nonatomic) NSArray *sections;
+@property (nonatomic) BOOL sectionsNeedUpdating;
 
 @end
 
@@ -43,66 +65,66 @@ static NSString *const ATLParticipantTableMiscellaneaSectionTitle = @"#";
 
 + (instancetype)dataSetWithParticipants:(NSSet *)participants sortType:(ATLParticipantPickerSortType)sortType
 {
-    NSSortDescriptor *sortDescriptor;
-    switch (sortType) {
-        case ATLParticipantPickerSortTypeFirstName:
-            sortDescriptor = [NSSortDescriptor sortDescriptorWithKey:@"firstName" ascending:YES selector:@selector(localizedStandardCompare:)];
-            break;
-        case ATLParticipantPickerSortTypeLastName:
-            sortDescriptor = [NSSortDescriptor sortDescriptorWithKey:@"lastName" ascending:YES selector:@selector(localizedStandardCompare:)];
-            break;
-    }
-    NSArray *sortedParticipants = [participants sortedArrayUsingDescriptors:@[sortDescriptor]];
-
-    NSMutableArray *sections = [NSMutableArray new];
-    NSMutableArray *sectionTitles = [NSMutableArray new];
-    NSString *currentSectionTitle;
-    ATLParticipantTableSectionData *currentSectionData;
-    for (id<ATLParticipant> participant in sortedParticipants) {
-        NSString *name;
-        switch (sortType) {
-            case ATLParticipantPickerSortTypeFirstName:
-                name = participant.firstName;
-                break;
-            case ATLParticipantPickerSortTypeLastName:
-                name = participant.lastName;
-                break;
-        }
-        NSString *initial = [self initialForName:name];
-        if ([initial isEqualToString:currentSectionTitle]) {
-            NSRange range = currentSectionData.participantsRange;
-            range.length += 1;
-            currentSectionData.participantsRange = range;
-        } else {
-            currentSectionTitle = initial;
-            [sectionTitles addObject:currentSectionTitle];
-            ATLParticipantTableSectionData *priorSectionData = currentSectionData;
-            currentSectionData = [ATLParticipantTableSectionData new];
-            currentSectionData.participantsRange = NSMakeRange(NSMaxRange(priorSectionData.participantsRange), 1);
-            [sections addObject:currentSectionData];
-        }
-    }
-
-    ATLParticipantTableDataSet *dataSet = [self new];
-    dataSet.participants = sortedParticipants;
-    dataSet.sectionTitles = sectionTitles;
-    dataSet.sections = sections;
-    return dataSet;
+    return [[self alloc] initWithParticipants:participants sortType:sortType];
 }
 
-+ (NSString *)initialForName:(NSString *)name
+- (id)initWithParticipants:(NSSet *)participants sortType:(ATLParticipantPickerSortType)sortType
 {
-    if (name.length == 0) return ATLParticipantTableMiscellaneaSectionTitle;
-    NSString *initial = [name substringToIndex:1];
-    initial = [initial decomposedStringWithCanonicalMapping];
-    if (initial.length > 1) {
-        initial = [initial substringToIndex:1];
+    self = [super init];
+    if (self) {
+        _participants = [participants.allObjects mutableCopy];
+        _sortType = sortType;
+        switch (self.sortType) {
+            case ATLParticipantPickerSortTypeFirstName:
+                _sortDescriptor = [NSSortDescriptor sortDescriptorWithKey:@"firstName" ascending:YES selector:@selector(localizedStandardCompare:)];
+                break;
+            case ATLParticipantPickerSortTypeLastName:
+                _sortDescriptor = [NSSortDescriptor sortDescriptorWithKey:@"lastName" ascending:YES selector:@selector(localizedStandardCompare:)];
+                break;
+        }
+        _sectionsNeedUpdating = YES;
     }
-    initial = initial.uppercaseString;
-    NSCharacterSet *uppercaseCharacters = [NSCharacterSet uppercaseLetterCharacterSet];
-    NSRange range = [initial rangeOfCharacterFromSet:uppercaseCharacters];
-    if (range.location == NSNotFound) return ATLParticipantTableMiscellaneaSectionTitle;
-    return initial;
+    return self;
+}
+
+#pragma mark -
+
+- (void) addParticipant:(id<ATLParticipant>)participant
+{
+    if (![self.participants containsObject:participant]) {
+        [self.participants addObject:participant];
+        self.sectionsNeedUpdating = YES;
+    }
+}
+
+- (void) removeParticipant:(id<ATLParticipant>)participant
+{
+    if ([self.participants containsObject:participant]) {
+        [self.participants removeObject:participant];
+        self.sectionsNeedUpdating = YES;
+    }
+}
+
+- (void) particpant:(id<ATLParticipant>)participant updatedProperty:(NSString *)property
+{
+    if ([self.participants containsObject:participant] && [self.sortDescriptor.key isEqualToString:property]) {
+        self.sectionsNeedUpdating = YES;
+    }
+}
+#pragma mark -
+
+- (NSArray *)sections
+{
+    [self updateSectionsIfNeeded];
+    NSAssert(_sections != nil, @"_sections did not get created");
+    return _sections;
+}
+
+- (NSArray<NSString *> *)sectionTitles
+{
+    [self updateSectionsIfNeeded];
+    NSAssert(_sectionTitles != nil, @"_sectionTitles did not get created");
+    return _sectionTitles;
 }
 
 - (NSUInteger)numberOfSections
@@ -137,6 +159,51 @@ static NSString *const ATLParticipantTableMiscellaneaSectionTitle = @"#";
         *stop = YES;
     }];
     return indexPath;
+}
+
+#pragma mark -
+
+- (void) updateSectionsIfNeeded
+{
+    if (!self.sectionsNeedUpdating) {
+        return;
+    }
+
+    NSArray *sortedParticipants = [self.participants sortedArrayUsingDescriptors:@[self.sortDescriptor]];
+
+    NSMutableArray *sections = [NSMutableArray new];
+    NSMutableArray *sectionTitles = [NSMutableArray new];
+    NSString *currentSectionTitle;
+    ATLParticipantTableSectionData *currentSectionData;
+    for (id<ATLParticipant> participant in sortedParticipants) {
+        NSString *name;
+        switch (self.sortType) {
+            case ATLParticipantPickerSortTypeFirstName:
+                name = participant.firstName;
+                break;
+            case ATLParticipantPickerSortTypeLastName:
+                name = participant.lastName;
+                break;
+        }
+        NSString *initial = ATLInitialForName(name);
+        if ([initial isEqualToString:currentSectionTitle]) {
+            NSRange range = currentSectionData.participantsRange;
+            range.length += 1;
+            currentSectionData.participantsRange = range;
+        } else {
+            currentSectionTitle = initial;
+            [sectionTitles addObject:currentSectionTitle];
+            ATLParticipantTableSectionData *priorSectionData = currentSectionData;
+            currentSectionData = [ATLParticipantTableSectionData new];
+            currentSectionData.participantsRange = NSMakeRange(NSMaxRange(priorSectionData.participantsRange), 1);
+            [sections addObject:currentSectionData];
+        }
+    }
+
+    self.participants = [sortedParticipants mutableCopy];
+    self.sections = sections;
+    self.sectionTitles = sectionTitles;
+    self.sectionsNeedUpdating = NO;
 }
 
 @end


### PR DESCRIPTION
Fix for APPS-2470. ATLParticipantTableDataSet is now "mutable". ATLParticipantTableViewController now observes LYRClient changes to identity objects and channels participant changes to the ATLParticipantTableDataSet, which in turn updates the section info which drives the table view.