### PR TITLE
fixes alignment constraint never removed so avatar is almost full width

### DIFF
--- a/Code/Views/ATLBaseCollectionViewCell.m
+++ b/Code/Views/ATLBaseCollectionViewCell.m
@@ -33,6 +33,7 @@ CGFloat const ATLAvatarImageTailPadding = 4.0f;
 @property (nonatomic) NSLayoutConstraint *bubbleWithAvatarLeadConstraint;
 @property (nonatomic) NSLayoutConstraint *bubbleWithoutAvatarLeadConstraint;
 @property (nonatomic) NSLayoutConstraint *bubbleViewWidthConstraint;
+@property (nonatomic) NSLayoutConstraint *avatarAlignmentConstraint;
 
 @property (nonatomic) BOOL messageSentState;
 @property (nonatomic) BOOL shouldDisplayAvatar;
@@ -161,15 +162,21 @@ CGFloat const ATLAvatarImageTailPadding = 4.0f;
         [self.contentView removeConstraint:self.bubbleWithoutAvatarLeadConstraint];
     }
     
+    if ([self.contentView.constraints containsObject:self.avatarAlignmentConstraint]) {
+        [self.contentView removeConstraint:self.avatarAlignmentConstraint];
+    }
+    
     switch (cellType) {
         case ATLIncomingCellType:
-            [self.contentView addConstraint:[NSLayoutConstraint constraintWithItem:self.avatarImageView attribute:NSLayoutAttributeLeft relatedBy:NSLayoutRelationEqual toItem:self.contentView attribute:NSLayoutAttributeLeft multiplier:1.0 constant:ATLAvatarImageLeadPadding]];
+            self.avatarAlignmentConstraint = [NSLayoutConstraint constraintWithItem:self.avatarImageView attribute:NSLayoutAttributeLeft relatedBy:NSLayoutRelationEqual toItem:self.contentView attribute:NSLayoutAttributeLeft multiplier:1.0 constant:ATLAvatarImageLeadPadding];
+            [self.contentView addConstraint:self.avatarAlignmentConstraint];
             self.bubbleWithAvatarLeadConstraint = [NSLayoutConstraint constraintWithItem:self.bubbleView attribute:NSLayoutAttributeLeft relatedBy:NSLayoutRelationEqual toItem:self.avatarImageView attribute:NSLayoutAttributeRight multiplier:1.0 constant:ATLAvatarImageTailPadding];
             [self.contentView addConstraint:self.bubbleWithAvatarLeadConstraint];
             self.bubbleWithoutAvatarLeadConstraint = [NSLayoutConstraint constraintWithItem:self.bubbleView attribute:NSLayoutAttributeLeft relatedBy:NSLayoutRelationEqual toItem:self.contentView attribute:NSLayoutAttributeLeft multiplier:1.0 constant:ATLMessageCellHorizontalMargin];
             break;
         case ATLOutgoingCellType:
-            [self.contentView addConstraint:[NSLayoutConstraint constraintWithItem:self.avatarImageView attribute:NSLayoutAttributeRight relatedBy:NSLayoutRelationEqual toItem:self.contentView attribute:NSLayoutAttributeRight multiplier:1.0 constant:-ATLAvatarImageLeadPadding]];
+            self.avatarAlignmentConstraint = [NSLayoutConstraint constraintWithItem:self.avatarImageView attribute:NSLayoutAttributeRight relatedBy:NSLayoutRelationEqual toItem:self.contentView attribute:NSLayoutAttributeRight multiplier:1.0 constant:-ATLAvatarImageLeadPadding];
+            [self.contentView addConstraint:self.avatarAlignmentConstraint];
             self.bubbleWithAvatarLeadConstraint = [NSLayoutConstraint constraintWithItem:self.avatarImageView attribute:NSLayoutAttributeLeft relatedBy:NSLayoutRelationEqual toItem:self.bubbleView attribute: NSLayoutAttributeRight multiplier:1.0 constant:ATLAvatarImageTailPadding];
             [self.contentView addConstraint:self.bubbleWithAvatarLeadConstraint];
             self.bubbleWithoutAvatarLeadConstraint = [NSLayoutConstraint constraintWithItem:self.bubbleView attribute:NSLayoutAttributeRight relatedBy:NSLayoutRelationEqual toItem:self.contentView attribute:NSLayoutAttributeRight multiplier:1.0 constant:-ATLMessageCellHorizontalMargin];


### PR DESCRIPTION
When calling -configureCellForType, the layout can incorrectly apply a near full width avatarImageView because the (12) padding on the left/right depending on the previous type was never removed. This PR persists and removes that constraint when the cellType is dynamically changed. This was not noticed if the cellType was never changed as is the case using ATLIncomingMessageCollectionViewCell / Outcoming as they are only set once.

This is what happened previously:
![simulator screen shot oct 14 2016 11 02 33 am](https://cloud.githubusercontent.com/assets/4205985/19399889/85b27796-9208-11e6-89cb-f81089a708f2.png)

Notice the 12-avatar-12 constraints which were left

![screen shot 2016-10-14 at 11 08 55 am](https://cloud.githubusercontent.com/assets/4205985/19399915/a8b59642-9208-11e6-860d-f7be85569b9a.png)

