### PR TITLE
Bug/last message nullability

### DIFF
--- a/Code/Controllers/ATLConversationListViewController.h
+++ b/Code/Controllers/ATLConversationListViewController.h
@@ -102,7 +102,7 @@ NS_ASSUME_NONNULL_BEGIN
  The cell must be given a reuse identifier in the UIStoryboard and that string needs to be passed into the ATLConversationListViewController so it can properly dequeue a
  reuseable cell. If 'nil' is returned, the table view will default to internal values for reuse identifiers.
  */
-- (NSString *)reuseIdentifierForConversationListViewController:(ATLConversationListViewController *)conversationListViewController;
+- (nullable NSString *)reuseIdentifierForConversationListViewController:(ATLConversationListViewController *)conversationListViewController;
 
 /**
  @abstract Asks the data source for a string to display on the delete button for a given deletion mode.
@@ -135,7 +135,7 @@ NS_ASSUME_NONNULL_BEGIN
  @return A string representing the content of the last message.  If `nil` is returned the controller will fall back to default behavior.
  @discussion This is used when the application uses custom `MIMEType`s and wants to customize how they are displayed.
  */
-- (NSString *)conversationListViewController:(ATLConversationListViewController *)conversationListViewController lastMessageTextForConversation:(LYRConversation *)conversation;
+- (nullable NSString *)conversationListViewController:(ATLConversationListViewController *)conversationListViewController lastMessageTextForConversation:(LYRConversation *)conversation;
 
 /**
  @abstract Asks the data source to configure the query used to fetch content for the controller if necessary.

--- a/Code/Controllers/ATLConversationViewController.h
+++ b/Code/Controllers/ATLConversationViewController.h
@@ -72,7 +72,7 @@ NS_ASSUME_NONNULL_BEGIN
  @discussion Applications should only return a value if the `message` object requires a custom cell class. If `nil` is returned, the collection view will default
  to internal height calculations.
  */
-- (CGFloat)conversationViewController:(ATLConversationViewController *)viewController heightForMessage:(LYRMessage *)message withCellWidth:(CGFloat)cellWidth;
+- (nullable CGFloat)conversationViewController:(ATLConversationViewController *)viewController heightForMessage:(LYRMessage *)message withCellWidth:(CGFloat)cellWidth;
 
 /**
  @abstract Informs the delegate of a cell being configured for the specified message.
@@ -156,7 +156,7 @@ NS_ASSUME_NONNULL_BEGIN
  @discussion Applications may implement this method to override the default behavior which is described below.
  If this method is not implemented or `nil` is returned, the conversation view controller will default to 1) disabling delivery receipts if there are more than five participants and 2) using an existing conversation between the participants if one already exists.
  */
-- (LYRConversation *)conversationViewController:(ATLConversationViewController *)viewController conversationWithParticipants:(NSSet *)participants;
+- (nullable LYRConversation *)conversationViewController:(ATLConversationViewController *)viewController conversationWithParticipants:(NSSet *)participants;
 
 /**
  @abstract Asks the data source to configure the default query used to fetch content for the controller if necessary.


### PR DESCRIPTION
Correcting nullability annotations for methods that describe returning nil will do the default behavior. This improves compatibility with swift code.
