### PR TITLE
Make the conversationDataSource a public property

### DIFF
--- a/Code/Controllers/ATLConversationViewController.h
+++ b/Code/Controllers/ATLConversationViewController.h
@@ -31,6 +31,7 @@ typedef NS_ENUM(NSUInteger, ATLAvatarItemDisplayFrequency) {
 };
 
 @class ATLConversationViewController;
+@class ATLConversationDataSource;
 @protocol ATLMessagePresenting;
 
 ///---------------------------------------
@@ -213,6 +214,11 @@ NS_ASSUME_NONNULL_BEGIN
  @abstract The `LYRConversation` object whose messages will be displayed in the controller.
  */
 @property (nonatomic) LYRConversation *conversation;
+
+/**
+ @abstract The `ATLConversationDataSource` responsible for managing the data to be displayed in the controller.
+ */
+@property (nonatomic) ATLConversationDataSource *conversationDataSource;
 
 /**
  @abstract The `LYRQueryController` object managing data displayed in the controller.

--- a/Code/Controllers/ATLConversationViewController.m
+++ b/Code/Controllers/ATLConversationViewController.m
@@ -36,7 +36,6 @@
 
 @interface ATLConversationViewController () <UICollectionViewDataSource, UICollectionViewDelegate, CLLocationManagerDelegate>
 
-@property (nonatomic) ATLConversationDataSource *conversationDataSource;
 @property (nonatomic, readwrite) LYRQueryController *queryController;
 @property (nonatomic) BOOL shouldDisplayAvatarItem;
 @property (nonatomic) NSMutableOrderedSet *typingParticipantIDs;


### PR DESCRIPTION
Useful for retrieving and inspecting messages of a given `indexPath` from `ATLConversationViewController`’s subclasses.