### PR TITLE
Add appearance setter for left participant padding

### DIFF
--- a/Code/Views/ATLConversationCollectionViewHeader.h
+++ b/Code/Views/ATLConversationCollectionViewHeader.h
@@ -47,6 +47,11 @@ extern NSString *const ATLConversationViewHeaderIdentifier;
 @property (nonatomic) UIColor *participantLabelTextColor UI_APPEARANCE_SELECTOR;
 
 /**
+ @abstract The left padding for the participant label displayed in the header. Default is 60.
+ */
+@property (nonatomic) CGFloat participantLabelLeftPadding UI_APPEARANCE_SELECTOR;
+
+/**
  @abstract Displays a string of text representing a participant. The string will be horizontally aligned with
  the left edge of the message bubble view.
  @param participantName The string of text to be displayed.

--- a/Code/Views/ATLConversationCollectionViewHeader.m
+++ b/Code/Views/ATLConversationCollectionViewHeader.m
@@ -25,6 +25,7 @@
 
 @property (nonatomic) UILabel *dateLabel;
 @property (nonatomic) UILabel *participantLabel;
+@property (nonatomic) NSLayoutConstraint* participantLabelLeftPaddingConstraint;
 
 @end
 
@@ -126,6 +127,12 @@ CGFloat const ATLConversationViewHeaderEmptyHeight = 1;
     self.participantLabel.textColor = participantLabelTextColor;
 }
 
+- (void)setParticipantLabelLeftPadding:(CGFloat)leftPadding
+{
+    _participantLabelLeftPaddingConstraint.constant = leftPadding;
+}
+
+
 + (CGFloat)headerHeightWithDateString:(NSAttributedString *)dateString participantName:(NSString *)participantName inView:(UIView *)view
 {
     if (!dateString && !participantName) return ATLConversationViewHeaderEmptyHeight;
@@ -172,7 +179,9 @@ CGFloat const ATLConversationViewHeaderEmptyHeight = 1;
 - (void)configureParticipantLabelConstraints
 {
     [self addConstraint:[NSLayoutConstraint constraintWithItem:self.participantLabel attribute:NSLayoutAttributeBottom relatedBy:NSLayoutRelationEqual toItem:self attribute:NSLayoutAttributeBottom multiplier:1.0 constant:-ATLConversationViewHeaderParticipantNameBottomPadding]];
-    [self addConstraint:[NSLayoutConstraint constraintWithItem:self.participantLabel attribute:NSLayoutAttributeLeft relatedBy:NSLayoutRelationEqual toItem:self attribute:NSLayoutAttributeLeft multiplier:1.0 constant:ATLConversationViewHeaderParticipantLeftPadding]];
+    self.participantLabelLeftPaddingConstraint = [NSLayoutConstraint constraintWithItem:self.participantLabel attribute:NSLayoutAttributeLeft relatedBy:NSLayoutRelationEqual toItem:self attribute:NSLayoutAttributeLeft multiplier:1.0 constant:ATLConversationViewHeaderParticipantLeftPadding];
+    [self addConstraint:_participantLabelLeftPaddingConstraint];
+
     
     // To work around an apparent system bug that initially requires the view to have zero width, instead of a required priority, we use a priority one higher than the content compression resistance.
     NSLayoutConstraint *participantLabelRightConstraint = [NSLayoutConstraint constraintWithItem:self.participantLabel attribute:NSLayoutAttributeRight relatedBy:NSLayoutRelationLessThanOrEqual toItem:self attribute:NSLayoutAttributeRight multiplier:1.0 constant:-ATLConversationViewHeaderHorizontalPadding];


### PR DESCRIPTION
Since we do not use the Avatar icon, we would like to change the default left padding of the participant label to a smaller value.
With the presented changes the left padding is customizable.