### PR TITLE
Fix PNG images not being displayed correctly in message bubbles

### DIFF
--- a/Code/Views/ATLMessageCollectionViewCell.m
+++ b/Code/Views/ATLMessageCollectionViewCell.m
@@ -459,6 +459,9 @@ NSInteger const kATLSharedCellTag = 1000;
         if (!imagePart) {
             // If no preview image part found, resort to the full-resolution image.
             imagePart = ATLMessagePartForMIMEType(message, ATLMIMETypeImageJPEG);
+            if (!imagePart) {
+                imagePart = ATLMessagePartForMIMEType(message, ATLMIMETypeImagePNG);
+            }
         }
         // Resort to image's size, if no dimensions metadata message parts found.
         if ((imagePart.transferStatus == LYRContentTransferComplete) ||


### PR DESCRIPTION
GIF and MP4 message parts may need the same fix.