### PR TITLE
APPS-2688 - Support for Conversations with Read Receipts Disabled

### DIFF
--- a/Atlas.podspec
+++ b/Atlas.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name                        = "Atlas"
-  s.version                     = '1.0.31'
+  s.version                     = '1.0.32'
   s.summary                     = "Atlas is a library of communications user interface components integrated with LayerKit."
   s.homepage                    = 'https://atlas.layer.com/'
   s.social_media_url            = 'http://twitter.com/layer'
@@ -21,5 +21,5 @@ Pod::Spec.new do |s|
   s.ios.resource_bundle         = { 'AtlasResource' => 'Resources/*' }
   s.ios.frameworks              = %w{ UIKit CoreLocation MobileCoreServices }
   s.ios.deployment_target       = '8.0'
-  s.dependency                  'LayerKit', '>= 0.23.0'
+  s.dependency                  'LayerKit', '>= 0.25.0'
 end

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 * Fixed an issue where pulling to load more messages in a conversations wouldn't work when it should
 
+### Enhancements
+
+* Added support for conversations with read receipts disabled. [APPS-2688]
+
 ## 1.0.31
 
 ### Enhancements

--- a/Code/Controllers/ATLConversationListViewController.m
+++ b/Code/Controllers/ATLConversationListViewController.m
@@ -429,6 +429,12 @@ NSString *const ATLConversationListViewControllerDeletionModeEveryone = @"Everyo
                 [self deleteConversationAtIndexPath:indexPath withDeletionMode:deletionMode.integerValue];
             }];
             deleteAction.backgroundColor = actionColor;
+            LYRConversation *conversation = [self.queryController objectAtIndexPath:indexPath];
+            if (!conversation.readReceiptsEnabled && deletionMode.integerValue == LYRDeletionModeMyDevices) {
+                // Disable support for synchronized deletion for
+                // conversations that have read receipts disabled.
+                continue;
+            }
             [actions addObject:deleteAction];
         }
     }

--- a/Code/Controllers/ATLConversationViewController.m
+++ b/Code/Controllers/ATLConversationViewController.m
@@ -461,7 +461,7 @@ static NSInteger const ATLPhotoActionSheet = 1000;
     } else {
         [cell updateWithSender:nil];
     }
-    if (message.isUnread && [[UIApplication sharedApplication] applicationState] == UIApplicationStateActive && self.marksMessagesAsRead) {
+    if (message.isUnread && [[UIApplication sharedApplication] applicationState] == UIApplicationStateActive && self.marksMessagesAsRead && self.conversation.readReceiptsEnabled) {
         [message markAsRead:nil];
     }
 }

--- a/Examples/Mocks/LYRConversationMock.h
+++ b/Examples/Mocks/LYRConversationMock.h
@@ -32,6 +32,8 @@
 @property (nonatomic, readonly, weak) LYRMessageMock *lastMessage LYR_QUERYABLE_PROPERTY;
 @property (nonatomic, readonly) BOOL hasUnreadMessages LYR_QUERYABLE_PROPERTY;
 @property (nonatomic, readonly) BOOL isDeleted;
+@property (nonatomic, readwrite) BOOL deliveryReceiptsEnabled;
+@property (nonatomic, readwrite) BOOL readReceiptsEnabled;
 @property (nonatomic, readonly) NSDictionary *metadata;
 @property (nonatomic, readonly) NSUInteger totalNumberOfMessages;
 

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,15 +1,15 @@
 PODS:
-  - Atlas (1.0.31):
-    - LayerKit (>= 0.23.0)
+  - Atlas (1.0.32):
+    - LayerKit (>= 0.25.0)
   - Expecta (1.0.5)
   - KIF (3.5.1):
     - KIF/Core (= 3.5.1)
   - KIF/Core (3.5.1)
   - KIFViewControllerActions (1.0.2):
     - KIF (>= 2.0.0)
-  - LayerKit (0.23.2)
+  - LayerKit (0.25.0)
   - LYRCountDownLatch (0.9.0)
-  - OCMock (3.3.1)
+  - OCMock (3.4)
 
 DEPENDENCIES:
   - Atlas (from `.`)
@@ -37,14 +37,14 @@ CHECKOUT OPTIONS:
     :git: https://github.com/layerhq/LYRCountDownLatch.git
 
 SPEC CHECKSUMS:
-  Atlas: 47ecba14740d7521cacb5e22e1dc4ee8359db126
+  Atlas: 5044148d34341f56be7c70b503c5c644fdfb3097
   Expecta: e1c022fcd33910b6be89c291d2775b3fe27a89fe
   KIF: 082eb65279e51c3092923802849eb796a04982ab
   KIFViewControllerActions: 923795dc4bd4ca5657841ce7455ce67447693861
-  LayerKit: 247c0099a6c09ef8ac9fd93ded3559d81dcfdc31
+  LayerKit: 2c92ab1325af22f9f62d00cd1e878903f87eb9b6
   LYRCountDownLatch: 9b440b42a19ddbf4e75bdd4b43726baa1527606a
-  OCMock: f3f61e6eaa16038c30caa5798c5e49d3307b6f22
+  OCMock: 35ae71d6a8fcc1b59434d561d1520b9dd4f15765
 
 PODFILE CHECKSUM: 9e55be12cb563fcf55f618983ac3ed4ed828761c
 
-COCOAPODS: 1.2.0
+COCOAPODS: 1.1.1

--- a/Tests/ATLConversationListViewControllerTest.m
+++ b/Tests/ATLConversationListViewControllerTest.m
@@ -137,6 +137,21 @@ extern NSString *const ATLAvatarImageViewAccessibilityLabel;
     [self deleteConversation:conversation1 deletionMode:LYRDeletionModeMyDevices];
 }
 
+//Test swipe to delete only shows global delete option.
+- (void)testToVerifyOnlyGlobalDeleteShowsWhenSwiped
+{
+    self.viewController = [ATLSampleConversationListViewController conversationListViewControllerWithLayerClient:(LYRClient *)self.testInterface.layerClient];
+    [self setRootViewController:self.viewController];
+    
+    NSString *message1 = @"Message1";
+    ATLUserMock *mockUser1 = [ATLUserMock userWithMockUserName:ATLMockUserNameKlemen];
+    LYRConversationMock *conversation1 = [self.testInterface conversationWithParticipants:[NSSet setWithObject:mockUser1.userID] lastMessageText:message1];
+    conversation1.readReceiptsEnabled = NO;
+    [tester swipeViewWithAccessibilityLabel:[self.testInterface conversationLabelForConversation:conversation1] inDirection:KIFSwipeDirectionLeft];
+    NSString *const ATLConversationListViewControllerDeletionModeMyDevices = @"My Devices";
+    [tester waitForAbsenceOfViewWithAccessibilityLabel:ATLConversationListViewControllerDeletionModeMyDevices];
+}
+
 //Test editing mode and deleting several conversations at once. Verify that all conversations selected are deleted from the table and from the Layer client.
 - (void)testToVerifyEditingModeAndMultipleConversationDeletionFunctionality
 {


### PR DESCRIPTION
This change prevents Atlas from making any calls to client's or conversation's mark message as read method, and disables the "My Devices" delete feature on the conversation view controller.