### PR TITLE
Prevent ATLAvatarImageView from “flashing” when setting the same remoteImageURL’s image

### DIFF
--- a/Code/Views/ATLAvatarImageView.m
+++ b/Code/Views/ATLAvatarImageView.m
@@ -24,6 +24,7 @@
 
 @property (nonatomic) UILabel *initialsLabel;
 @property (nonatomic) NSURLSessionDownloadTask *downloadTask;
+@property (nonatomic) NSURL *remoteImageURL;
 
 @end
 
@@ -184,6 +185,12 @@ NSString *const ATLAvatarImageViewAccessibilityLabel = @"ATLAvatarImageViewAcces
 
 - (void)updateWithImage:(UIImage *)image forRemoteImageURL:(NSURL *)remoteImageURL;
 {
+    if (self.remoteImageURL.absoluteString == remoteImageURL.absoluteString) {
+        return;
+    }
+    
+    NSLog(@"updateWithImage %p : %@ : %@", self, image, remoteImageURL.absoluteString);
+    
     [UIView animateWithDuration:0.2 animations:^{
         self.alpha = 0.0;
     } completion:^(BOOL finished) {

--- a/Code/Views/ATLAvatarImageView.m
+++ b/Code/Views/ATLAvatarImageView.m
@@ -188,6 +188,7 @@ NSString *const ATLAvatarImageViewAccessibilityLabel = @"ATLAvatarImageViewAcces
     if (self.remoteImageURL.absoluteString == remoteImageURL.absoluteString) {
         return;
     }
+    self.remoteImageURL = remoteImageURL;
     
     [UIView animateWithDuration:0.2 animations:^{
         self.alpha = 0.0;

--- a/Code/Views/ATLAvatarImageView.m
+++ b/Code/Views/ATLAvatarImageView.m
@@ -189,8 +189,6 @@ NSString *const ATLAvatarImageViewAccessibilityLabel = @"ATLAvatarImageViewAcces
         return;
     }
     
-    NSLog(@"updateWithImage %p : %@ : %@", self, image, remoteImageURL.absoluteString);
-    
     [UIView animateWithDuration:0.2 animations:^{
         self.alpha = 0.0;
     } completion:^(BOOL finished) {


### PR DESCRIPTION
When setting the image for the the same remoteImageURL the avatar view would set its alpha to 0.0 and then animate the image again, which looks weird then using the exact same image.