### PR TITLE
Fixes messageInputToolbar presenting

### DIFF
--- a/Code/Controllers/ATLConversationViewController.m
+++ b/Code/Controllers/ATLConversationViewController.m
@@ -768,6 +768,9 @@ static NSInteger const ATLPhotoActionSheet = 1000;
         } else {
             ATLMediaAttachment *mediaAttachment = [ATLMediaAttachment mediaAttachmentWithAssetURL:assetURL thumbnailSize:ATLDefaultThumbnailSize];
             [self.messageInputToolbar insertMediaAttachment:mediaAttachment withEndLineBreak:YES];
+            [self.view resignFirstResponder];
+            [self.messageInputToolbar.textInputView becomeFirstResponder];
+            [self.view setNeedsUpdateConstraints];
         }
     });
 }


### PR DESCRIPTION
• When tapping on the camera button, it gives the option to choose “Last Photo/Video”. When selecting this option, the action sheet disappears but the messageInputToolbar never reappears. This fixes that issue.