### PR TITLE
Fixes crash that results from Apple's UICollectionView bug https://openradar.appspot.com/28167779

### DIFF
--- a/Code/Controllers/ATLConversationViewController.m
+++ b/Code/Controllers/ATLConversationViewController.m
@@ -1268,7 +1268,12 @@ static NSInteger const ATLPhotoActionSheet = 1000;
             for (ATLDataSourceChange *change in objectChanges) {
                 switch (change.type) {
                     case LYRQueryControllerChangeTypeInsert:
-                        [self.collectionView insertSections:[NSIndexSet indexSetWithIndex:change.newIndex]];
+                        // For inserts, changes should only be inserted if changes aren't already available
+                        NSUInteger collectionCount = self.collectionView.numberOfSections;
+                        NSUInteger controllerCount = queryController.count;
+                        if (collectionCount <= controllerCount) {
+                            [self.collectionView insertSections:[NSIndexSet indexSetWithIndex:change.newIndex]];
+                        }
                         break;
                         
                     case LYRQueryControllerChangeTypeMove:


### PR DESCRIPTION
This prevents the view controller from crashing when Apple's UICollectionView bug for inserts manifests itself.