### PR TITLE
Allow for Clients to Update the Conversation List Predicate

### DIFF
--- a/Code/Controllers/ATLConversationListViewController.h
+++ b/Code/Controllers/ATLConversationListViewController.h
@@ -288,7 +288,7 @@ NS_ASSUME_NONNULL_BEGIN
  @abstract Updates the predicate used to perform searches.
  @param predicate The predicate to use; `nil` is permitted.
  */
-- (void)updatePredicate:(nullable LYRPredicate *)predicate;
+- (void)updatePredicate:(nullable LYRPredicate *)predicate NS_SWIFT_NAME(update(predicate:));
 
 @end
 NS_ASSUME_NONNULL_END

--- a/Code/Controllers/ATLConversationListViewController.h
+++ b/Code/Controllers/ATLConversationListViewController.h
@@ -280,5 +280,15 @@ NS_ASSUME_NONNULL_BEGIN
  */
 - (void)reloadCellForConversation:(LYRConversation *)conversation;
 
+///------------------------------
+/// @name Reloading Conversations
+///------------------------------
+
+/**
+ @abstract Updates the predicate used to perform searches.
+ @param predicate The predicate to use; `nil` is permitted.
+ */
+- (void)updatePredicate:(nullable LYRPredicate *)predicate;
+
 @end
 NS_ASSUME_NONNULL_END

--- a/Code/Controllers/ATLConversationListViewController.m
+++ b/Code/Controllers/ATLConversationListViewController.m
@@ -252,6 +252,11 @@ NSString *const ATLConversationListViewControllerDeletionModeEveryone = @"Everyo
     _rowHeight = rowHeight;
 }
 
+- (void)updatePredicate:(nullable LYRPredicate *)predicate
+{
+    [self updateQueryControllerWithPredicate:predicate];
+}
+
 #pragma mark - Set Up
 
 - (void)addEditButton


### PR DESCRIPTION
# Summary
This PR allows for clients who leverage Atlas to update the predicate that [`ATLConversationListViewController`](https://github.com/layerhq/Atlas-iOS/blob/master/Code/Controllers/ATLConversationListViewController.h) uses to populate itself.

# Approach
I added a new method, [`updatePredicate:`](https://github.com/Snagajob/Atlas-iOS/commit/52e8fd2ba8c781f74a45093eb038564b7782bbc8#diff-4f587823069094564d475f3c2be66523R291), which allows for the `LYRPredicate` to be updated. This method simply calls the private [`updateQueryControllerWithPredicate `](https://github.com/layerhq/Atlas-iOS/blob/master/Code/Controllers/ATLConversationListViewController.m#L642-L649).

# Rationale
In our app, we have the following situation:

* A view loads `ATLConversationListViewController` with a subset of all available conversations
* Based on user action, the subset of conversations needs to change–thus, the `LYRPredicate` needs to change
* We wish to do this without destroying/creating a new controller

The easiest way I could find to do so was to escalate access to `updateQueryControllerWithPredicate` to be public. I changed the name of the public version because it seemed a bit of a leaky abstraction to declare that it's a `QueryController` that we're changing the predicate on.

This approach was tentatively blessed [by @daniel-maness in Slack](https://layer.slack.com/archives/C570YUG5S/p1509126216000169).

# Notes
This is my first PR to Atlas/Layer, so if I'm getting anything procedurally wrong, do let me know. I'm happy to re-issue this PR to a different branch, add other changes, etc. Let me know what else you need from me!