### PR TITLE
#1431: fixed ATLAvatarView's imageViewBackgroundColor handling

### DIFF
--- a/Code/Views/ATLAvatarView.m
+++ b/Code/Views/ATLAvatarView.m
@@ -171,7 +171,7 @@ NSString *const ATLAvatarViewAccessibilityLabel = @"ATLAvatarViewAccessibilityLa
 
 - (void)setImageViewBackgroundColor:(UIColor *)imageViewBackgroundColor
 {
-    self.backgroundColor = imageViewBackgroundColor;
+    self.imageView.backgroundColor = imageViewBackgroundColor;
     _imageViewBackgroundColor = imageViewBackgroundColor;
 }
 


### PR DESCRIPTION
Changes:
* fix for #1431 (ATLAvatarView's imageViewBackgroundColor sets backgroundColor, not image view's background color);