### PR TITLE
Fixed ATLMessageInputToolbar layout according to safe area insets

### DIFF
--- a/Code/Controllers/ATLBaseConversationViewController.m
+++ b/Code/Controllers/ATLBaseConversationViewController.m
@@ -199,7 +199,9 @@ static CGFloat const ATLMaxScrollDistanceFromBottom = 150;
 - (void)scrollToBottomAnimated:(BOOL)animated
 {
     CGSize contentSize = self.collectionView.contentSize;
-    [self.collectionView setContentOffset:[self bottomOffsetForContentSize:contentSize] animated:animated];
+    CGPoint contentOffset = [self bottomOffsetForContentSize:contentSize];
+    contentOffset.x = self.collectionView.contentOffset.x;
+    [self.collectionView setContentOffset:contentOffset animated:animated];
 }
 
 #pragma mark - Content Inset Management  

--- a/Code/Utilities/UICollectionView+ATLHelpers.h
+++ b/Code/Utilities/UICollectionView+ATLHelpers.h
@@ -1,0 +1,29 @@
+//
+//  UICollectionView+ATLHelpers.h
+//  Atlas
+//
+//  Created by Łukasz Przytuła on 09.11.2017.
+//  Copyright (c) 2017 Layer. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+#import <UIKit/UIKit.h>
+
+@interface UICollectionView (ATLHelpers)
+
+@property (nonatomic, readonly) UIEdgeInsets atl_adjustedContentInset;
+
+- (void)atl_setupContentInsetAdjustmentBehavior;
+
+@end

--- a/Code/Utilities/UICollectionView+ATLHelpers.m
+++ b/Code/Utilities/UICollectionView+ATLHelpers.m
@@ -1,0 +1,63 @@
+//
+//  UICollectionView+ATLHelpers.m
+//  Atlas
+//
+//  Created by Łukasz Przytuła on 09.11.2017.
+//  Copyright (c) 2017 Layer. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+#import "UICollectionView+ATLHelpers.h"
+
+@implementation UICollectionView (ATLHelpers)
+
+- (UIEdgeInsets)atl_adjustedContentInset {
+    SEL selector = NSSelectorFromString(@"adjustedContentInset");
+    static BOOL adjustedContentInsetAvailable;
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+        adjustedContentInsetAvailable = [self respondsToSelector:selector];
+    });
+    if (!adjustedContentInsetAvailable) {
+        return self.contentInset;
+    }
+    NSInvocation *invocation = [NSInvocation invocationWithMethodSignature:
+                                [[self class] instanceMethodSignatureForSelector:selector]];
+    [invocation setSelector:selector];
+    [invocation setTarget:self];
+    [invocation invoke];
+    UIEdgeInsets returnValue;
+    [invocation getReturnValue:&returnValue];
+    return returnValue;
+}
+
+- (void)atl_setupContentInsetAdjustmentBehavior {
+    SEL selector = NSSelectorFromString(@"setContentInsetAdjustmentBehavior:");
+    static BOOL setContentInsetAdjustmentBehaviorAvailable;
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+        setContentInsetAdjustmentBehaviorAvailable = [self respondsToSelector:selector];
+    });
+    if (setContentInsetAdjustmentBehaviorAvailable) {
+        NSInvocation *invocation = [NSInvocation invocationWithMethodSignature:
+                                    [[self class] instanceMethodSignatureForSelector:selector]];
+        [invocation setSelector:selector];
+        [invocation setTarget:self];
+        NSInteger value = 3;
+        [invocation setArgument:&value atIndex:2];
+        [invocation invoke];
+    }
+}
+
+@end

--- a/Code/Utilities/UIView+ATLHelpers.h
+++ b/Code/Utilities/UIView+ATLHelpers.h
@@ -1,0 +1,27 @@
+//
+//  UIView+ATLHelpers.h
+//  Atlas
+//
+//  Created by Łukasz Przytuła on 09.11.2017.
+//  Copyright (c) 2017 Layer. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+#import <UIKit/UIKit.h>
+
+@interface UIView (ATLHelpers)
+
+@property (nonatomic, readonly) UIEdgeInsets atl_safeAreaInsets;
+
+@end

--- a/Code/Utilities/UIView+ATLHelpers.m
+++ b/Code/Utilities/UIView+ATLHelpers.m
@@ -1,0 +1,45 @@
+//
+//  UIView+ATLHelpers.m
+//  Atlas
+//
+//  Created by Łukasz Przytuła on 09.11.2017.
+//  Copyright (c) 2017 Layer. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+#import "UIView+ATLHelpers.h"
+
+@implementation UIView (ATLHelpers)
+
+- (UIEdgeInsets)atl_safeAreaInsets {
+    SEL selector = NSSelectorFromString(@"safeAreaInsets");
+    static BOOL safeAreaInsetsAvailable;
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+        safeAreaInsetsAvailable = [self respondsToSelector:selector];
+    });
+    if (!safeAreaInsetsAvailable) {
+        return UIEdgeInsetsZero;
+    }
+    NSInvocation *invocation = [NSInvocation invocationWithMethodSignature:
+                                [[self class] instanceMethodSignatureForSelector:selector]];
+    [invocation setSelector:selector];
+    [invocation setTarget:self];
+    [invocation invoke];
+    UIEdgeInsets returnValue;
+    [invocation getReturnValue:&returnValue];
+    return returnValue;
+}
+
+@end

--- a/Code/Views/ATLMessageInputToolbar.m
+++ b/Code/Views/ATLMessageInputToolbar.m
@@ -21,6 +21,7 @@
 #import "ATLConstants.h"
 #import "ATLMediaAttachment.h"
 #import "ATLMessagingUtilities.h"
+#import "UIView+ATLHelpers.h"
 
 NSString *const ATLMessageInputToolbarDidChangeHeightNotification = @"ATLMessageInputToolbarDidChangeHeightNotification";
 
@@ -121,6 +122,8 @@ static CGFloat const ATLButtonHeight = 28.0f;
         self.firstAppearance = NO;
     }
     
+    UIEdgeInsets safeAreaInsets = [self atl_safeAreaInsets];
+    
     // set the font for the dummy text view as well
     self.dummyTextView.font = self.textInputView.font;
     
@@ -144,7 +147,7 @@ static CGFloat const ATLButtonHeight = 28.0f;
     }
     
     leftButtonFrame.size.height = ATLButtonHeight;
-    leftButtonFrame.origin.x = ATLLeftButtonHorizontalMargin;
+    leftButtonFrame.origin.x = ATLLeftButtonHorizontalMargin + safeAreaInsets.left;
 
     if (self.rightAccessoryButtonFont && (self.textInputView.text.length || !self.displaysRightAccessoryImage)) {
         rightButtonFrame.size.width = CGRectIntegral([ATLLocalizedString(@"atl.messagetoolbar.send.key", self.rightAccessoryButtonTitle, nil) boundingRectWithSize:CGSizeMake(MAXFLOAT, MAXFLOAT) options:0 attributes:@{NSFontAttributeName: self.rightAccessoryButtonFont} context:nil]).size.width + ATLRightAccessoryButtonPadding;
@@ -153,7 +156,8 @@ static CGFloat const ATLButtonHeight = 28.0f;
     }
     
     rightButtonFrame.size.height = ATLButtonHeight;
-    rightButtonFrame.origin.x = CGRectGetWidth(frame) - CGRectGetWidth(rightButtonFrame) - ATLRightButtonHorizontalMargin;
+    rightButtonFrame.origin.x = CGRectGetWidth(frame) - CGRectGetWidth(rightButtonFrame) -
+                                ATLRightButtonHorizontalMargin - safeAreaInsets.right;
 
     textViewFrame.origin.x = CGRectGetMaxX(leftButtonFrame) + ATLLeftButtonHorizontalMargin;
     textViewFrame.origin.y = self.verticalMargin;
@@ -163,15 +167,15 @@ static CGFloat const ATLButtonHeight = 28.0f;
     CGSize fittedTextViewSize = [self.dummyTextView sizeThatFits:CGSizeMake(CGRectGetWidth(textViewFrame), MAXFLOAT)];
     textViewFrame.size.height = ceil(MIN(fittedTextViewSize.height, self.textViewMaxHeight));
 
-    frame.size.height = CGRectGetHeight(textViewFrame) + self.verticalMargin * 2;
+    frame.size.height = CGRectGetHeight(textViewFrame) + self.verticalMargin * 2 + safeAreaInsets.bottom;
     frame.origin.y -= frame.size.height - CGRectGetHeight(self.frame);
  
     // Only calculate button centerY once to anchor it to bottom of bar.
     if (!self.buttonCenterY) {
         self.buttonCenterY = (CGRectGetHeight(frame) - CGRectGetHeight(leftButtonFrame)) / 2;
     }
-    leftButtonFrame.origin.y = frame.size.height - leftButtonFrame.size.height - self.buttonCenterY;
-    rightButtonFrame.origin.y = frame.size.height - rightButtonFrame.size.height - self.buttonCenterY;
+    leftButtonFrame.origin.y = frame.size.height - leftButtonFrame.size.height - self.buttonCenterY - safeAreaInsets.bottom;
+    rightButtonFrame.origin.y = frame.size.height - rightButtonFrame.size.height - self.buttonCenterY - safeAreaInsets.bottom;
     
     BOOL heightChanged = CGRectGetHeight(textViewFrame) != CGRectGetHeight(self.textInputView.frame);
 


### PR DESCRIPTION
Fixes #1426 

Added ```safeAreaInsets.bottom``` to the ```ATLMessageInputToolbar``` height and subviews during layout so it's not overlapped on iPhone X.

<img width="211" alt="zrzut ekranu 2017-11-09 o 12 38 50" src="https://user-images.githubusercontent.com/2022644/32604515-2a3ba82c-c54e-11e7-93cf-589b23cbbd0d.png"><img width="211" alt="zrzut ekranu 2017-11-09 o 12 38 43" src="https://user-images.githubusercontent.com/2022644/32604517-2c849b8e-c54e-11e7-9c8f-6d0414056576.png">
<img width="206" alt="zrzut ekranu 2017-11-09 o 12 58 33" src="https://user-images.githubusercontent.com/2022644/32604520-2f90ff70-c54e-11e7-91c3-8a5ee444e0bf.png"><img width="206" alt="zrzut ekranu 2017-11-09 o 12 58 37" src="https://user-images.githubusercontent.com/2022644/32604522-31edef26-c54e-11e7-819e-bfde0e173f97.png">
![zrzut ekranu 2017-11-09 o 23 31 13](https://user-images.githubusercontent.com/2022644/32633023-2496e028-c5a6-11e7-8522-a54e29dd3878.png)
![zrzut ekranu 2017-11-09 o 23 31 16](https://user-images.githubusercontent.com/2022644/32633025-269b1542-c5a6-11e7-9315-33238786bb49.png)
