### PR TITLE
Fixed crash in converstaion view controller

### DIFF
--- a/Code/Models/ATLConversationDataSource.h
+++ b/Code/Models/ATLConversationDataSource.h
@@ -99,5 +99,20 @@ NS_ASSUME_NONNULL_BEGIN
  */
 - (nullable LYRMessage *)messageAtCollectionViewSection:(NSInteger)collectionViewSection;
 
+/**
+ @abstract Returns an `ATLConversationViewController` index path of the given message
+ */
+- (NSIndexPath *)collectionViewIndexPathForMessage:(LYRMessage *)message;
+
+/**
+ @abstract Returns number of messages available for presenting in conversation view.
+ */
+- (NSUInteger)numberOfMessages;
+
+/**
+ @abstract Updates data source with current state of query controller messages.
+ */
+- (void)updateMessages;
+
 @end
 NS_ASSUME_NONNULL_END

--- a/Code/Models/ATLConversationDataSource.m
+++ b/Code/Models/ATLConversationDataSource.m
@@ -44,6 +44,7 @@ LYRConversation *LYRConversationDataSourceConversationFromPredicate(LYRPredicate
 
 @interface ATLConversationDataSource ()
 
+@property (atomic, copy) NSOrderedSet<LYRMessage *> *messages;
 @property (nonatomic, readwrite) LYRQueryController *queryController;
 @property (nonatomic, readwrite) BOOL expandingPaginationWindow;
 @property (nonatomic, readwrite) LYRConversation *conversation;
@@ -201,15 +202,31 @@ NSInteger const ATLQueryControllerPaginationWindow = 30;
 - (LYRMessage *)messageAtCollectionViewIndexPath:(NSIndexPath *)collectionViewIndexPath
 {
     NSIndexPath *queryControllerIndexPath = [self queryControllerIndexPathForCollectionViewIndexPath:collectionViewIndexPath];
-    LYRMessage *message = [self.queryController objectAtIndexPath:queryControllerIndexPath];
+    LYRMessage *message = [self.messages objectAtIndex:queryControllerIndexPath.row];
     return message;
 }
 
 - (LYRMessage *)messageAtCollectionViewSection:(NSInteger)collectionViewSection
 {
     NSIndexPath *queryControllerIndexPath = [self queryControllerIndexPathForCollectionViewSection:collectionViewSection];
-    LYRMessage *message = [self.queryController objectAtIndexPath:queryControllerIndexPath];
+    LYRMessage *message = [self.messages objectAtIndex:queryControllerIndexPath.row];
     return message;
+}
+
+- (NSIndexPath *)collectionViewIndexPathForMessage:(LYRMessage *)message {
+    NSUInteger messageIndex = [self.messages indexOfObject:message];
+    if (messageIndex == NSNotFound) {
+        return nil;
+    }
+    return [self collectionViewIndexPathForQueryControllerRow:messageIndex];
+}
+
+- (NSUInteger)numberOfMessages {
+    return self.messages.count;
+}
+
+- (void)updateMessages {
+    self.messages = self.queryController.paginatedObjects;
 }
 
 @end

--- a/Examples/Mocks/LYRQueryControllerMock.h
+++ b/Examples/Mocks/LYRQueryControllerMock.h
@@ -42,6 +42,7 @@
 @property (nonatomic) NSSet *updatableProperties;
 @property (nonatomic) NSInteger paginationWindow;
 @property (nonatomic, readonly) NSUInteger totalNumberOfObjects;
+@property (nonatomic, strong) NSOrderedSet *paginatedObjects;
 
 + (instancetype)initWithQuery:(LYRQuery *)query;
 

--- a/Examples/Mocks/LYRQueryControllerMock.m
+++ b/Examples/Mocks/LYRQueryControllerMock.m
@@ -49,6 +49,11 @@
     return self;
 }
 
+- (NSOrderedSet *)paginatedObjects
+{
+    return self.objects;
+}
+
 - (NSUInteger)numberOfSections
 {
     return 1;

--- a/fastlane/Scanfile
+++ b/fastlane/Scanfile
@@ -1,1 +1,2 @@
 device "iPhone 6"
+include_simulator_logs false


### PR DESCRIPTION
Fixes #1230 and fixes #1164

```ATLConversationDataSource``` keeps a copy of messages for presentation in ```ATLConversationViewController```, so whenever ```reloadData``` is called, it uses a shapshot of messages set, instead of all messages currently held by query controller. The copy of messages in ```ATLConversationDataSource``` is updated only during ```performBatchUpdates``` inside ```queryControllerDidChangeContent:``` delegate method, and that prevents the crash.
