### PR TITLE
[IOS-3310] Fixed carthage support

### DIFF
--- a/Atlas.xcodeproj/project.pbxproj
+++ b/Atlas.xcodeproj/project.pbxproj
@@ -7,6 +7,9 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		150813781FD826AC0069802E /* UIView+ATLHelpers.m in Sources */ = {isa = PBXBuildFile; fileRef = 150813731FD826AB0069802E /* UIView+ATLHelpers.m */; };
+		150813791FD826AC0069802E /* UIMutableUserNotificationAction+ATLHelpers.m in Sources */ = {isa = PBXBuildFile; fileRef = 150813741FD826AB0069802E /* UIMutableUserNotificationAction+ATLHelpers.m */; };
+		1508137A1FD826AC0069802E /* UICollectionView+ATLHelpers.m in Sources */ = {isa = PBXBuildFile; fileRef = 150813751FD826AB0069802E /* UICollectionView+ATLHelpers.m */; };
 		3DA2FAC31F1E9DAE00E890FA /* block.png in Resources */ = {isa = PBXBuildFile; fileRef = 7858B60C1CE54BBE007795AB /* block.png */; };
 		3DA2FAC41F1E9DAE00E890FA /* block@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = 7858B60D1CE54BBE007795AB /* block@2x.png */; };
 		3DA2FAC51F1E9DAE00E890FA /* block@3x.png in Resources */ = {isa = PBXBuildFile; fileRef = 7858B60E1CE54BBE007795AB /* block@3x.png */; };
@@ -242,6 +245,12 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		150813721FD826AB0069802E /* UIMutableUserNotificationAction+ATLHelpers.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "UIMutableUserNotificationAction+ATLHelpers.h"; sourceTree = "<group>"; };
+		150813731FD826AB0069802E /* UIView+ATLHelpers.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "UIView+ATLHelpers.m"; sourceTree = "<group>"; };
+		150813741FD826AB0069802E /* UIMutableUserNotificationAction+ATLHelpers.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "UIMutableUserNotificationAction+ATLHelpers.m"; sourceTree = "<group>"; };
+		150813751FD826AB0069802E /* UICollectionView+ATLHelpers.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "UICollectionView+ATLHelpers.m"; sourceTree = "<group>"; };
+		150813761FD826AB0069802E /* UIView+ATLHelpers.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "UIView+ATLHelpers.h"; sourceTree = "<group>"; };
+		150813771FD826AC0069802E /* UICollectionView+ATLHelpers.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "UICollectionView+ATLHelpers.h"; sourceTree = "<group>"; };
 		1886043CF840E83E9A77B78B /* Pods_UnitTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_UnitTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		250C5EF21C7656610084EB18 /* LayerKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = LayerKit.framework; path = Carthage/Build/iOS/LayerKit.framework; sourceTree = "<group>"; };
 		34C06B1C4F6FE86629A3C050 /* Pods-test-ProgrammaticTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-test-ProgrammaticTests.release.xcconfig"; path = "Pods/Target Support Files/Pods-test-ProgrammaticTests/Pods-test-ProgrammaticTests.release.xcconfig"; sourceTree = "<group>"; };
@@ -551,6 +560,12 @@
 		3DA2FAF51F1E9DF500E890FA /* Utilities */ = {
 			isa = PBXGroup;
 			children = (
+				150813771FD826AC0069802E /* UICollectionView+ATLHelpers.h */,
+				150813751FD826AB0069802E /* UICollectionView+ATLHelpers.m */,
+				150813721FD826AB0069802E /* UIMutableUserNotificationAction+ATLHelpers.h */,
+				150813741FD826AB0069802E /* UIMutableUserNotificationAction+ATLHelpers.m */,
+				150813761FD826AB0069802E /* UIView+ATLHelpers.h */,
+				150813731FD826AB0069802E /* UIView+ATLHelpers.m */,
 				3DA2FAF61F1E9DF500E890FA /* ATLConstants.h */,
 				3DA2FAF71F1E9DF500E890FA /* ATLConstants.m */,
 				3DA2FAF81F1E9DF500E890FA /* ATLErrors.h */,
@@ -1516,6 +1531,9 @@
 			files = (
 				D02CDCDD1A9FFC930013CBE8 /* ATLTestUtilities.m in Sources */,
 				D0294DE81A93F39300702856 /* ATLMediaStreamTests.m in Sources */,
+				1508137A1FD826AC0069802E /* UICollectionView+ATLHelpers.m in Sources */,
+				150813791FD826AC0069802E /* UIMutableUserNotificationAction+ATLHelpers.m in Sources */,
+				150813781FD826AC0069802E /* UIView+ATLHelpers.m in Sources */,
 				D04517141A9F9A0C00E137D9 /* ATLMediaAttachmentTests.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -1663,6 +1681,7 @@
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(PROJECT_DIR)/Pods/LayerKit",
 					"../releases-ios/**",
+					"../../Build/**",
 				);
 				GCC_C_LANGUAGE_STANDARD = gnu99;
 				GCC_DYNAMIC_NO_PIC = NO;
@@ -1715,6 +1734,7 @@
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(PROJECT_DIR)/Pods/LayerKit",
 					"../releases-ios/**",
+					"../../Build/**",
 				);
 				GCC_C_LANGUAGE_STANDARD = gnu99;
 				GCC_TREAT_WARNINGS_AS_ERRORS = YES;

--- a/Atlas.xcodeproj/xcshareddata/xcschemes/Atlas-Carthage.xcscheme
+++ b/Atlas.xcodeproj/xcshareddata/xcschemes/Atlas-Carthage.xcscheme
@@ -26,6 +26,7 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      language = ""
       shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
       </Testables>
@@ -36,6 +37,7 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      language = ""
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
       ignoresPersistentStateOnLaunch = "NO"

--- a/circle.yml
+++ b/circle.yml
@@ -3,7 +3,9 @@ machine:
     version: 9.0
 dependencies:
   pre:
+    - brew install carthage
     - gem install bundler
 test:
   override:
+    - carthage build --no-skip-current
     - bundle exec fastlane test


### PR DESCRIPTION
I've added test Carthage build to CI, and it properly failed with:
```
carthage build --no-skip-current
*** xcodebuild output can be found in /var/folders/ms/xg67k5sn16xc7sdr_w3q45840000gn/T/carthage-xcodebuild.lZSxBf.log
*** Cloning releases-ios
*** Building scheme "Atlas" in Atlas.xcworkspace
Build Failed
	Task failed with exit code 65:
	/usr/bin/xcrun xcodebuild -workspace /Users/distiller/Atlas-iOS/Atlas.xcworkspace -scheme Atlas -configuration Release -sdk iphoneos ONLY_ACTIVE_ARCH=NO BITCODE_GENERATION_MODE=bitcode CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY= CARTHAGE=YES archive -archivePath ./ SKIP_INSTALL=YES GCC_INSTRUMENT_PROGRAM_FLOW_ARCS=NO CLANG_ENABLE_CODE_COVERAGE=NO (launched in /Users/distiller/Atlas-iOS)

This usually indicates that project itself failed to compile. Please check the xcodebuild log for more details: /var/folders/ms/xg67k5sn16xc7sdr_w3q45840000gn/T/carthage-xcodebuild.lZSxBf.log

carthage build --no-skip-current returned exit code 1
```

Then I've fixed the target for Carthage build (added missing files), and renamed scheme to ```Atlas-Carthage```, as previous scheme name ```Atlas``` caused Carthage was building all schemes starting with ```Atlas```:
```
=== BUILD TARGET Atlas OF PROJECT Atlas WITH CONFIGURATION Release ===
=== BUILD TARGET Atlas-AtlasResource OF PROJECT Pods WITH CONFIGURATION Release ===
=== BUILD TARGET Atlas OF PROJECT Pods WITH CONFIGURATION Release ===
```
in a random order, and whenever ```Atlas OF PROJECT Atlas``` wasn't built as the last one, it failed, as derived data was cleaned before other builds, and framework wasn't there, which caused an error:
```
Failed to write to [...]Atlas-iOS/Carthage/Build/iOS/Atlas.framework: Error Domain=NSCocoaErrorDomain Code=260 "The file “Atlas.framework” couldn’t be opened because there is no such file." UserInfo={NSURL=file://[...]/DerivedData/Atlas-esnwokudrddqngcyrfiirrndvdfp/Build/Intermediates.noindex/ArchiveIntermediates/Atlas/BuildProductsPath/Release-iphoneos/Atlas.framework, NSFilePath=[...]/DerivedData/Atlas-esnwokudrddqngcyrfiirrndvdfp/Build/Intermediates.noindex/ArchiveIntermediates/Atlas/BuildProductsPath/Release-iphoneos/Atlas.framework, NSUnderlyingError=0x7ffe4fc9d220 {Error Domain=NSPOSIXErrorDomain Code=2 "No such file or directory"}}
```