### PR TITLE
Fixed installing carthage for tests in CircleCI

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -3,7 +3,8 @@ machine:
     version: 9.0
 dependencies:
   pre:
-    - brew install carthage
+    - brew update
+    - brew install carthage || brew upgrade carthage
     - gem install bundler
 test:
   override:


### PR DESCRIPTION
Carthage installation step was failing randomly, on workers that already had it installed.