### PR TITLE
Location message sent when delegate request that no message is sent

### DIFF
--- a/Code/Controllers/ATLConversationViewController.m
+++ b/Code/Controllers/ATLConversationViewController.m
@@ -618,8 +618,14 @@ static NSInteger const ATLPhotoActionSheet = 1000;
         return;
     }
     
+    if (self.addressBarController) [self.addressBarController disable];
+    
     // If there's no content in the input field, send the location.
     NSOrderedSet *messages = [self messagesForMediaAttachments:messageInputToolbar.mediaAttachments];
+    
+    // Don't send message if nil
+    if (!messages) return;
+    
     if (messages.count == 0 && messageInputToolbar.textInputView.text.length == 0) {
         [self sendLocationMessage];
     } else {
@@ -627,7 +633,6 @@ static NSInteger const ATLPhotoActionSheet = 1000;
             [self sendMessage:message];
         }
     }
-    if (self.addressBarController) [self.addressBarController disable];
 }
 
 - (void)messageInputToolbarDidType:(ATLMessageInputToolbar *)messageInputToolbar


### PR DESCRIPTION
According the the documentation comments above `ATLConversationViewControllerDelegate messagesForMediaAttachments`
```
If `nil` is returned, the controller will fall back to default behavior. If an empty
 `NSOrderedSet` is returned, the controller will not send any messages.
```

However returning an empty set will cause the location message to be set. This PR fixes that so that functionality matches the documentation comment